### PR TITLE
remove spammy log

### DIFF
--- a/persistence/leafreadwriter.go
+++ b/persistence/leafreadwriter.go
@@ -54,7 +54,6 @@ func (l *LeafReader) ReadNext() ([]byte, error) {
 	ret := make([]byte, merkle.NodeSize)
 	_, err := l.b.Read(ret)
 	if err != nil {
-		log.Error("failed to read in leaf reader: %v", err)
 		return nil, err
 	}
 	return ret, nil


### PR DESCRIPTION
The PoST labels are always read until EOF is reached, so this is not really an error and shouldn't be logged.