### PR TITLE
Parallelism support

### DIFF
--- a/initialization/initialize_test.go
+++ b/initialization/initialize_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/spacemeshos/post/persistence"
 	"github.com/spacemeshos/post/proving"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
@@ -27,7 +26,7 @@ var (
 func TestInitialize(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialize(defaultId, defaultSpace, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialize(defaultId, defaultSpace, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	expectedMerkleRoot := hexDecode("2292f95c87626f5a281fa811ba825ffce79442f8999e1ddc8e8c9bbac15e3fcb")
@@ -57,30 +56,31 @@ func TestInitialize(t *testing.T) {
 func TestInitializeErrors(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialize(defaultId, defaultSpace, defaultSpace, defaultNumOfProvenLabels, 4)
+	proof, err := initialize(defaultId, defaultSpace, defaultSpace, defaultNumOfProvenLabels, 4, false)
 	r.EqualError(err, "difficulty must be between 5 and 8 (received 4)")
 	r.Nil(proof)
 
-	proof, err = initialize(defaultId, defaultSpace, defaultSpace, defaultNumOfProvenLabels, 9)
+	proof, err = initialize(defaultId, defaultSpace, defaultSpace, defaultNumOfProvenLabels, 9, false)
 	r.EqualError(err, "difficulty must be between 5 and 8 (received 9)")
 	r.Nil(proof)
 
-	proof, err = initialize(defaultId, MaxSpace+1, defaultSpace, NumOfProvenLabels, defaultDifficulty)
+	proof, err = initialize(defaultId, MaxSpace+1, defaultSpace, NumOfProvenLabels, defaultDifficulty, false)
 	r.EqualError(err, fmt.Sprintf("space (%d) is greater than the supported max (%d)", MaxSpace+1, MaxSpace))
 	r.Nil(proof)
 }
 
 func TestInitializeMultipleFiles(t *testing.T) {
 	r := require.New(t)
+	space := uint64(defaultSpace)
 
-	proof, err := initialize(defaultId, defaultSpace, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialize(defaultId, space, space, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 	execProof, err := proving.GenerateProof(defaultId, defaultChallenge, defaultNumOfProvenLabels, defaultDifficulty)
 	r.NoError(err)
 
 	for numOfFiles := uint64(2); numOfFiles <= 16; numOfFiles *= 2 {
 		cleanup()
-		multiFilesProof, err := initialize(defaultId, defaultSpace, defaultSpace/numOfFiles, defaultNumOfProvenLabels, defaultDifficulty)
+		multiFilesProof, err := initialize(defaultId, space, space/numOfFiles, defaultNumOfProvenLabels, defaultDifficulty, true)
 		r.NoError(err)
 		multiFilesExecProof, err := proving.GenerateProof(defaultId, defaultChallenge, defaultNumOfProvenLabels, defaultDifficulty)
 		r.NoError(err)
@@ -112,11 +112,11 @@ func (n nodes) String() string {
 
 func BenchmarkInitialize(b *testing.B) {
 	space := uint64(1) << 30 // 1 GB.
-	proof, err := initialize(defaultId, space, space, NumOfProvenLabels, defaultDifficulty)
+	_, err := initialize(defaultId, space, space, NumOfProvenLabels, defaultDifficulty, false)
 	require.NoError(b, err)
 
-	expectedMerkleRoot, _ := hex.DecodeString("42dd3ed26e6f30f8098ec0b5093147551b32573ef9ed6670076248b4fd0fac30")
-	assert.Equal(b, expectedMerkleRoot, proof.MerkleRoot)
+	//expectedMerkleRoot, _ := hex.DecodeString("42dd3ed26e6f30f8098ec0b5093147551b32573ef9ed6670076248b4fd0fac30")
+	//assert.Equal(b, expectedMerkleRoot, proof.MerkleRoot)
 	/*
 		2019-04-30T11:49:10.271+0300    INFO    Spacemesh       creating directory: "/Users/moshababo/.spacemesh-data/post-data/deadbeef"
 		2019-04-30T11:49:45.168+0300    INFO    Spacemesh       found 5000000 labels

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -28,7 +28,7 @@ var (
 func TestValidate(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	err = Validate(proof, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
@@ -42,7 +42,7 @@ func TestValidate2(t *testing.T) {
 
 	const difficulty = 6
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, difficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, difficulty, false)
 	r.NoError(err)
 
 	err = Validate(proof, defaultSpace, defaultNumOfProvenLabels, difficulty)
@@ -56,7 +56,7 @@ func TestValidate3(t *testing.T) {
 
 	const difficulty = 7
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, difficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, difficulty, false)
 	r.NoError(err)
 
 	err = Validate(proof, defaultSpace, defaultNumOfProvenLabels, difficulty)
@@ -70,7 +70,7 @@ func TestValidate4(t *testing.T) {
 
 	const difficulty = 8
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, difficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, difficulty, false)
 	r.NoError(err)
 
 	err = Validate(proof, defaultSpace, defaultNumOfProvenLabels, difficulty)
@@ -109,7 +109,7 @@ func TestGenerateProofFailure(t *testing.T) {
 func TestValidateFail(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	proof.Identity = append([]byte{0}, proof.Identity[1:]...)
@@ -121,7 +121,7 @@ func TestValidateFail(t *testing.T) {
 func TestValidateFail2(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	proof.Challenge = []byte{1}
@@ -133,7 +133,7 @@ func TestValidateFail2(t *testing.T) {
 func TestValidateFail3(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	proof.ProvenLeaves[0] = append([]byte{}, proof.ProvenLeaves[0]...)
@@ -146,7 +146,7 @@ func TestValidateFail3(t *testing.T) {
 func TestValidateFail4(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	proof.ProvenLeaves = proof.ProvenLeaves[1:]
@@ -158,7 +158,7 @@ func TestValidateFail4(t *testing.T) {
 func TestValidateFail5(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	proof.ProofNodes[0] = append([]byte{}, proof.ProofNodes[0]...)
@@ -171,7 +171,7 @@ func TestValidateFail5(t *testing.T) {
 func TestValidateFail6(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	proof.ProofNodes = proof.ProofNodes[1:]
@@ -183,7 +183,7 @@ func TestValidateFail6(t *testing.T) {
 func TestValidateFail7(t *testing.T) {
 	r := require.New(t)
 
-	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty)
+	proof, err := initialization.Initialize(defaultId, defaultSpace, defaultNumOfProvenLabels, defaultDifficulty, false)
 	r.NoError(err)
 
 	proof.MerkleRoot = append([]byte{}, proof.MerkleRoot...)


### PR DESCRIPTION
Adding parallelism support, based on https://github.com/spacemeshos/post/pull/12.

Number of workers (goroutines) is: `min(num of cpus, num of files)`.
Number of files is not adjusted yet. Used only in tests.

Basic _initialization_ benchmarks:
````
1.1GB space
32 files
12 CPUs (6 physical)

no parallelism: 235 sec
no parallelism 1 file: 243 sec
parallel: workers as num of files (32): 64 sec
parallel: workers as num of cpus (12): 63 sec
````
````
2.2GB space
32 files
12 CPUs (6 physical)

no parallelism:  476 sec
no parallelism 1 file: 501 sec
parallel: workers as num of files (32): 128 sec
parallel: workers as num of cpus (12): 131 sec
parallel: workers as num of cpus / 2 (6): 137 sec
parallel: workers as num of cpus / 4 (3): 210 sec
````