### PR TITLE
init: workers channel batches

### DIFF
--- a/initialization/initialize.go
+++ b/initialization/initialize.go
@@ -203,29 +203,28 @@ func (init *Initializer) initFile(id []byte, fileIndex int, labelGroupsPerFile u
 	errChan := make(chan error, 0)
 	finishedChan := make(chan struct{}, 0)
 	batchSize := 100
-	chanBuffer := 100
+	chanBufferSize := 100
 
 	// CPU workers.
 	fileOffset := uint64(fileIndex) * labelGroupsPerFile
 	for i := 0; i < numOfWorkers; i++ {
 		i := i
-		workersOutputChans[i] = make(chan [][]byte, chanBuffer)
+		workersOutputChans[i] = make(chan [][]byte, chanBufferSize)
 		workerOffset := i
 		go func() {
 			// Calculate labels in groups and write them to channel in batches.
-			iterator := 0
-			position := uint64(workerOffset)
+			position := uint64(workerOffset * batchSize)
 			batch := make([][]byte, batchSize)
 			for position < labelGroupsPerFile {
-				batch[iterator%batchSize] = CalcLabelGroup(id, position+fileOffset, Difficulty(init.cfg.Difficulty))
+				batch[position%uint64(batchSize)] = CalcLabelGroup(id, position+fileOffset, Difficulty(init.cfg.Difficulty))
 
-				if iterator%batchSize == batchSize-1 {
+				if position%uint64(batchSize) == uint64(batchSize-1) {
 					workersOutputChans[i] <- batch
 					batch = make([][]byte, batchSize)
+					position += uint64(numOfWorkers * batchSize)
 				}
 
-				iterator += 1
-				position += uint64(numOfWorkers)
+				position += 1
 			}
 			workersOutputChans[i] <- batch
 		}()
@@ -233,20 +232,13 @@ func (init *Initializer) initFile(id []byte, fileIndex int, labelGroupsPerFile u
 
 	// IO worker.
 	go func() {
-	loop:
-		for batchesIterator := 0; ; batchesIterator++ {
-			// Consume next batch from all workers.
-			batches := make([][][]byte, numOfWorkers)
-			for i, workerChan := range workersOutputChans {
-				batches[i] = <-workerChan
-			}
-
-			// Consume label groups from the batches in round-robin fashion.
-			for i := 0; i < batchSize*numOfWorkers; i++ {
-				batch := batches[i%numOfWorkers]
-				lg := batch[i/numOfWorkers]
+	batchesLoop:
+		for i := 0; ; i++ {
+			// Consume the next batch from the next worker.
+			batch := <-workersOutputChans[i%numOfWorkers]
+			for j, lg := range batch {
 				if lg == nil {
-					break loop
+					break batchesLoop
 				}
 
 				// Write label group to disk, and append it as leaf in the merkle tree.
@@ -261,11 +253,10 @@ func (init *Initializer) initFile(id []byte, fileIndex int, labelGroupsPerFile u
 					return
 				}
 
-				num := i + 1 + batchSize*numOfWorkers*batchesIterator
+				num := batchSize*i + j + 1
 				if uint64(num)%init.cfg.LabelsLogRate == 0 {
 					init.logger.Info("initialization: file %v completed %v label groups", fileIndex, num)
 				}
-
 			}
 		}
 

--- a/initialization/initialize.go
+++ b/initialization/initialize.go
@@ -241,12 +241,15 @@ func (init *Initializer) initFile(id []byte, fileIndex int, labelGroupsPerFile u
 					break batchesLoop
 				}
 
-				// Write label group to disk, and append it as leaf in the merkle tree.
+				// Write label group to disk.
 				err := labelsWriter.Write(lg)
 				if err != nil {
 					errChan <- err
 					return
 				}
+
+				// Append label group as leaf in the merkle tree. The tree cache
+				// isn't suppose to handle writing of the leaf layer (0) to disk.
 				err = tree.AddLeaf(lg)
 				if err != nil {
 					errChan <- err

--- a/initialization/initialize.go
+++ b/initialization/initialize.go
@@ -221,7 +221,7 @@ func (init *Initializer) initFile(id []byte, fileIndex int, labelGroupsPerFile u
 				if position%uint64(batchSize) == uint64(batchSize-1) {
 					workersOutputChans[i] <- batch
 					batch = make([][]byte, batchSize)
-					position += uint64(numOfWorkers * batchSize)
+					position += uint64((numOfWorkers - 1) * batchSize)
 				}
 
 				position += 1

--- a/initialization/initialize_test.go
+++ b/initialization/initialize_test.go
@@ -110,6 +110,10 @@ func TestInitializeErrors(t *testing.T) {
 func TestInitializeMultipleFiles(t *testing.T) {
 	r := require.New(t)
 
+	cfg := cfg
+	cfg.SpacePerUnit = 1 << 15
+	cfg.FileSize = 1 << 15
+
 	initProof, err := NewInitializer(cfg, logger).Initialize(id)
 	r.NoError(err)
 


### PR DESCRIPTION
CPU workers to produce label groups in batches, in attempt to reduce channel ops overhead.

## Benchmarks

### INIT 2GB | 6 in-file parallelism
 before: 2m7s
 after: 1m58s

time % before | time % after | function 
-- | -- | -- 
24 | 39 | github.com/spacemeshos/sha256-simd.blockAvx2 (cpu)
6 | 8 | syscall.Syscall (disk write)
14 | 12 | runtime.pthread_cond_signal (chan ops)
26 | 16 | runtime.pthread_cond_wait (chan ops)
8 | 1 | runtime.usleep 

### INIT 2GB | no parallelism
before: 10m7s
after: 7m43s
**no channels: 8m32s**


time % before | time % after | time % no-channels | function 
-- | -- | -- | --
0.5 | 6 | 11 |  github.com/spacemeshos/sha256-simd.blockAvx2 (cpu)
3 | 5 | 75 | syscall.Syscall (disk write)
59 | 73 | 2 | runtime.pthread_cond_signal (chan ops)
23 | 9 | 2 | runtime.pthread_cond_wait (chan ops)
10 | 1 | 0 | runtime.usleep

