### PR TITLE
Init state inspection to return configMismatch even if init is completed

### DIFF
--- a/initialization/initializer.go
+++ b/initialization/initializer.go
@@ -520,14 +520,14 @@ func (init *Initializer) State() (state, uint64, error) {
 		return 0, 0, err
 	}
 
+	if !configMatch(&metadata.Cfg, init.cfg) {
+		return 0, 0, ErrStateConfigMismatch
+	}
+
 	switch metadata.State {
 	case MetadataStateCompleted:
 		return StateCompleted, 0, nil
 	case MetadataStateStarted:
-		if !configMatch(&metadata.Cfg, init.cfg) {
-			return 0, 0, ErrStateConfigMismatch
-		}
-
 		for _, file := range initFiles {
 			if requiredSpace < uint64(file.Size()) {
 				return 0, 0, ErrStateInconsistent

--- a/initialization/initializer_blackbox_test.go
+++ b/initialization/initializer_blackbox_test.go
@@ -206,21 +206,26 @@ func TestInitializer_State(t *testing.T) {
 	_, err = init.Initialize()
 	r.Equal(err, shared.ErrInitCompleted)
 
-	// Initialize using a new instance with a different config.
+	// Use a new instance with a different config.
 
-	cfg.SpacePerUnit = 1 << 14
-	cfg.FileSize = 1 << 14
+	newCfg := cfg
+	newCfg.SpacePerUnit = 1 << 14
+	newCfg.FileSize = 1 << 14
 
-	init = NewInitializer(&cfg, id)
+	init = NewInitializer(&newCfg, id)
 
-	state, requiredSpace, err = init.State()
-	r.Equal(StateCompleted, state)
-	r.Equal(uint64(0), requiredSpace)
-	r.NoError(err)
+	_, _, err = init.State()
+	r.Equal(err, initialization.ErrStateConfigMismatch)
 
 	_, err = init.Initialize()
-	r.Equal(err, shared.ErrInitCompleted)
+	r.Equal(err, initialization.ErrStateConfigMismatch)
 
+	err = init.Reset()
+	r.Equal(err, initialization.ErrStateConfigMismatch)
+
+	// Reset with the correct config.
+
+	init = NewInitializer(&cfg, id)
 	err = init.Reset()
 	r.NoError(err)
 }

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -132,14 +132,14 @@ func TestGenerateProofFailure(t *testing.T) {
 	r := require.New(t)
 
 	newCfg := *cfg
-	newCfg.Difficulty = 4
+	newCfg.Difficulty = 6
 
 	init := NewInitializer(cfg, id)
 	_, err := init.Initialize()
 	r.NoError(err)
 
 	proof, err := NewProver(&newCfg, id).GenerateProof(challenge)
-	r.EqualError(err, fmt.Sprintf("proof generation failed: difficulty must be between 5 and 8 (received %d)", newCfg.Difficulty))
+	r.EqualError(err, "proof generation failed: initialization state error: config mismatch")
 	r.Empty(proof)
 
 	err = init.Reset()


### PR DESCRIPTION
Changing initialization state inspection so that it will return `configMismatch` error even if initialization is completed.
This is mainly to avoid a scenario wheres execution is called with different space param, but proof is being generated in respective to the previous param, and no error is being reported or blocking the user call. 
