### PR TITLE
Don't enforce NumProvenLabels config mismatch

### DIFF
--- a/initialization/initializer.go
+++ b/initialization/initializer.go
@@ -591,6 +591,5 @@ func (init *Initializer) isInitFile(file os.FileInfo) bool {
 func configMatch(cfg1 *config.Config, cfg2 *config.Config) bool {
 	return cfg1.SpacePerUnit == cfg2.SpacePerUnit &&
 		cfg1.NumFiles == cfg2.NumFiles &&
-		cfg1.Difficulty == cfg2.Difficulty &&
-		cfg1.NumProvenLabels == cfg2.NumProvenLabels
+		cfg1.Difficulty == cfg2.Difficulty
 }


### PR DESCRIPTION
Don't enforce a requirement that the config `NumProvenLabels` param would be the same as when the init files were generated. This is unnecessary, since this param doesn't affect the generated data, but only the proofs, which can vary. 