### PR TITLE
Less allocations in GetSha256Parent

### DIFF
--- a/shared/challenge.go
+++ b/shared/challenge.go
@@ -6,17 +6,18 @@ type Challenge []byte
 
 var (
 	ZeroChallenge = make(Challenge, 0)
-	message []byte
+	buffer        []byte
 )
 
-// ⚠️ This method is NOT thread-safe
+// ⚠️ This method is NOT thread-safe. The code is optimized for performance and memory allocations.
 func (ch Challenge) GetSha256Parent(lChild, rChild []byte) []byte {
-	if len(message) != len(ch)+len(lChild)+len(rChild) {
-		message = make([]byte, len(ch)+len(lChild)+len(rChild))
+	l := len(ch) + len(lChild) + len(rChild)
+	if len(buffer) < l {
+		buffer = make([]byte, l)
 	}
-	copy(message, ch)
-	copy(message[len(ch):], lChild)
-	copy(message[len(ch)+len(lChild):], rChild)
-	res := sha256.Sum256(message)
+	copy(buffer, ch)
+	copy(buffer[len(ch):], lChild)
+	copy(buffer[len(ch)+len(lChild):], rChild)
+	res := sha256.Sum256(buffer[:l])
 	return res[:]
 }

--- a/shared/challenge.go
+++ b/shared/challenge.go
@@ -4,10 +4,19 @@ import "github.com/spacemeshos/sha256-simd"
 
 type Challenge []byte
 
-var ZeroChallenge = make(Challenge, 0)
+var (
+	ZeroChallenge = make(Challenge, 0)
+	message []byte
+)
 
+// ⚠️ This method is NOT thread-safe
 func (ch Challenge) GetSha256Parent(lChild, rChild []byte) []byte {
-	children := append(lChild, rChild...)
-	res := sha256.Sum256(append(ch, children...))
+	if len(message) != len(ch)+len(lChild)+len(rChild) {
+		message = make([]byte, len(ch)+len(lChild)+len(rChild))
+	}
+	copy(message, ch)
+	copy(message[len(ch):], lChild)
+	copy(message[len(ch)+len(lChild):], rChild)
+	res := sha256.Sum256(message)
 	return res[:]
 }


### PR DESCRIPTION
closes https://github.com/spacemeshos/go-spacemesh/issues/1617

---

@y0sher noticed that `GetSha256Parent` allocates a lot of memory during PoST proofs. Looking at the code, this makes sense: each `append` allocates memory for a new backing array.

I've looked into how I can reduce allocations and tried the following benchmarks:

```golang
func BenchmarkCombine(b *testing.B) {
	x := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
	y := []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
	z := []byte("cccccccccccccccccccccccccccccccc")
	var q []byte

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		q = combineGlobal(x, y, z)
	}
	println(q)
}

func combineAppend(x, y, z []byte) []byte {
	message := append(x, append(y, z...)...)
	return message
	// 84.9 ns/op
}

func combineString(x, y, z []byte) []byte {
	message := []byte(string(x) + string(y) + string(z))
	return message
	// 112 ns/op
}

func combineCopy(x, y, z []byte) []byte {
	message := make([]byte, len(x) + len(y) + len(z))
	copy(message, x)
	copy(message[len(x):], y)
	copy(message[len(x)+len(y):], z)
	return message
	// 65.2 ns/op
}

var m []byte

func combineGlobal(x, y, z []byte) []byte {
	if len(m) != len(x) + len(y) + len(z) {
		m = make([]byte, len(x) + len(y) + len(z))
	}
	copy(m, x)
	copy(m[len(x):], y)
	copy(m[len(x)+len(y):], z)
	return m
	// 13.0 ns/op
}

var buf = bytes.Buffer{}

func combineBuff(x, y, z []byte) []byte {
	buf.Reset()
	buf.Write(x)
	buf.Write(y)
	buf.Write(z)
	return buf.Bytes()
	// 24.5 ns/op
}
```

`combineAppend` was what we previously did, and it looks like `combineString` is even worse (and probably causes more allocations, since each string has to be allocated separately), but it was a nice try.

`combineCopy` is an improvement, but it only really saves us a single allocation.

`combineGlobal` is what I ended up going with. It has a major downside that it's not thread safe, but it ammortizes the only allocation that doesn't have to happen, as long as the lengths of the byte arrays remain constant (in our case they do).

`combineBuff` could be a nice alternative. It's also not thread-safe, but it responds better to changing sizes and it's a little more readable, for a slightly increased runtime.