### PR TITLE
Generate get parent func

### DIFF
--- a/initialization/initializer.go
+++ b/initialization/initializer.go
@@ -303,7 +303,7 @@ func (init *Initializer) initFile(fileIndex int, labelGroupsPerFile uint64, infi
 	// Initialize the labels merkle tree with the execution-phase zero challenge.
 	cacheWriter := cache.NewWriter(cache.MinHeightPolicy(init.cfg.LowestLayerToCacheDuringProofGeneration), cache.MakeSliceReadWriterFactory())
 	tree, err := merkle.NewTreeBuilder().
-		WithHashFunc(shared.ZeroChallenge.GetSha256Parent).
+		WithHashFunc(shared.ZeroChallenge.GenerateGetParentFunc()).
 		WithCacheWriter(cacheWriter).
 		Build()
 	if err != nil {

--- a/proving/prover.go
+++ b/proving/prover.go
@@ -115,7 +115,7 @@ func (p *Prover) generateMTree(reader LayerReadWriter, challenge Challenge) (*MT
 	cacheWriter := cache.NewWriter(cache.MinHeightPolicy(p.cfg.LowestLayerToCacheDuringProofGeneration),
 		cache.MakeSliceReadWriterFactory())
 
-	tree, err := merkle.NewTreeBuilder().WithHashFunc(challenge.GetSha256Parent).WithCacheWriter(cacheWriter).Build()
+	tree, err := merkle.NewTreeBuilder().WithHashFunc(challenge.GenerateGetParentFunc()).WithCacheWriter(cacheWriter).Build()
 	if err != nil {
 		return nil, err
 	}

--- a/shared/challenge.go
+++ b/shared/challenge.go
@@ -4,20 +4,21 @@ import "github.com/spacemeshos/sha256-simd"
 
 type Challenge []byte
 
-var (
-	ZeroChallenge = make(Challenge, 0)
-	buffer        []byte
-)
+var ZeroChallenge = make(Challenge, 0)
 
-// ⚠️ This method is NOT thread-safe. The code is optimized for performance and memory allocations.
-func (ch Challenge) GetSha256Parent(lChild, rChild []byte) []byte {
-	l := len(ch) + len(lChild) + len(rChild)
-	if len(buffer) < l {
-		buffer = make([]byte, l)
+// ⚠️ The resulting method is NOT thread-safe, however different generated instances are independent.
+// The code is optimized for performance and memory allocations.
+func (ch Challenge) GenerateGetParentFunc() func(lChild, rChild []byte) []byte {
+	var buffer []byte
+	return func(lChild, rChild []byte) []byte {
+		l := len(ch) + len(lChild) + len(rChild)
+		if len(buffer) < l {
+			buffer = make([]byte, l)
+		}
+		copy(buffer, ch)
+		copy(buffer[len(ch):], lChild)
+		copy(buffer[len(ch)+len(lChild):], rChild)
+		res := sha256.Sum256(buffer[:l])
+		return res[:]
 	}
-	copy(buffer, ch)
-	copy(buffer[len(ch):], lChild)
-	copy(buffer[len(ch)+len(lChild):], rChild)
-	res := sha256.Sum256(buffer[:l])
-	return res[:]
 }

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -61,7 +61,7 @@ func validate(identity []byte, proof proving.Proof, numLabelGroups uint64, numPr
 		proof.ProvenLeaves,
 		proof.ProofNodes,
 		proof.MerkleRoot,
-		proof.Challenge.GetSha256Parent,
+		proof.Challenge.GenerateGetParentFunc(),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Motivation
The node's `AppTest` runs several nodes in parallel, which causes the `GetSha256Parent ` function with a global buffer to return unexpected results (it's not thread safe).

### Changes
This replaces the static `GetSha256Parent` with `GenerateGetParentFunc`. The new function allocates a new `buffer` and generates the same function as before, but using a separate `buffer`.