### PR TITLE
proving: remove shared indices variable

### DIFF
--- a/proving/proving.go
+++ b/proving/proving.go
@@ -237,8 +237,6 @@ func (p *Prover) tryNonces(numLabels uint64, challenge Challenge, startNonce, en
 	gsReader := shared.NewGranSpecificReader(reader, p.cfg.BitsPerLabel)
 
 	numWorkers := endNonce - startNonce + 1
-	var indices []byte
-
 	workersChans := make([]chan []byte, numWorkers)
 	// workersComplete channel will be closed when worker stops listening for appropriate workersChan
 	workersComplete := make([]chan struct{}, numWorkers)
@@ -290,7 +288,7 @@ func (p *Prover) tryNonces(numLabels uint64, challenge Challenge, startNonce, en
 		wg.Add(1)
 		go func() {
 			nonce := startNonce + i
-			indices, err = p.tryNonce(ctx, numLabels, challenge, nonce, workersChans[i], difficulty)
+			indices, err := p.tryNonce(ctx, numLabels, challenge, nonce, workersChans[i], difficulty)
 			close(workersComplete[i])
 			resultsChan <- &nonceResult{nonce, indices, err}
 			wg.Done()


### PR DESCRIPTION
This was leading to a race with severe consequences, results from different tryNonce workers may mix up. More in https://github.com/spacemeshos/go-spacemesh/issues/2735.

`var indices []byte` is a shared variable that can be updated by concurrent goroutines. Consider this interleaving:

| G1 | G2 | |
| ---     | --- | --- | 
| indices = tryNonce(11) | | G1 completes tryNonce first |
| | indices = tryNonce(99) | G2 completes second, but before result from G1 is sent to channel |
| resultsChan <- result{indices} | resutlsChan <- result{indices} | both G1 and G2 are using indices from G2 | 

I think my previous change made it more likely to happen since I am always returning first proof sent to the channel, and previously we were returning the last proof sent. But it was still possible, because we can't guarantee any particular order. So if we change interleaving example slightly we can see how it can fail if we consume always last result:

| G1 | G2 | |
| ---     | --- | --- | 
| | indices = tryNonce(99) | G2 completes tryNonce first |
| indices = tryNonce(11) | | G1 completes second, but before result from G2 is sent to channel |
| resultsChan <- result{indices} | resutlsChan <- result{indices} | both G1 and G2 are using indices from G1 | 

