### PR TITLE
Align `numLabelsWritten` to prevent panic

### DIFF
--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -44,6 +44,10 @@ func CPUProviderID() int {
 }
 
 type Initializer struct {
+	// numLabelsWritten should be aligned by 8 bytes because it's accessed by atomics.
+	numLabelsWritten     uint64
+	numLabelsWrittenChan chan uint64
+
 	cfg  Config
 	opts InitOpts
 	id   []byte
@@ -51,9 +55,6 @@ type Initializer struct {
 	diskState    *DiskState
 	initializing bool
 	mtx          sync.RWMutex
-
-	numLabelsWritten     uint64
-	numLabelsWrittenChan chan uint64
 
 	stopChan chan struct{}
 	doneChan chan struct{}


### PR DESCRIPTION
Part of https://github.com/spacemeshos/go-spacemesh/issues/3107

`numLabelsWritten` should be aligned by 8 bytes to prevent panic on 32-bit ARM CPUs.

After merging, the version of https://github.com/spacemeshos/post used by https://github.com/spacemeshos/go-spacemesh should be updated
