### PR TITLE
show stat about generationg PoS files

### DIFF
--- a/initialization/stat.go
+++ b/initialization/stat.go
@@ -1,0 +1,33 @@
+package initialization
+
+import "sync/atomic"
+
+type LabelInfo struct {
+	Label        uint64
+	LabelInBytes uint64
+}
+
+func NewLabelInfo(label, bitsPerLabel uint64) LabelInfo {
+	return LabelInfo{
+		Label:        label,
+		LabelInBytes: label * bitsPerLabel / 8,
+	}
+}
+
+type InitializerStat struct {
+	TotalFilesToWrite uint64    // total number of files to write
+	CompletedFiles    uint64    // number of files that were actually written
+	LabelsPerFile     LabelInfo // number of labels in each file
+	WrittenAtLastFile LabelInfo // number of labels written to the last file
+}
+
+func (init *Initializer) SessionStat() InitializerStat {
+	labelsPerFile := init.getFileNumLabels()
+	writtenAtLast := atomic.LoadUint64(&init.numLabelsWritten)
+	return InitializerStat{
+		TotalFilesToWrite: uint64(init.opts.NumFiles),
+		CompletedFiles:    atomic.LoadUint64(&init.processedFiles),
+		WrittenAtLastFile: NewLabelInfo(writtenAtLast, uint64(init.cfg.BitsPerLabel)),
+		LabelsPerFile:     NewLabelInfo(labelsPerFile, uint64(init.cfg.BitsPerLabel)),
+	}
+}


### PR DESCRIPTION
related issue https://github.com/spacemeshos/go-spacemesh/issues/3281

for serving full status about generating PoS files was added new method.

as result - returning this struct
```
type InitializerStat struct {
	TotalFilesToWrite uint64    // total number of files to write
	CompletedFiles    uint64    // number of files that were actually written
	LabelsPerFile    LabelInfo{
	  Label        uint64
	  LabelInBytes uint64
        } // number of labels in each file
	WrittenAtLastFile LabelInfo // number of labels written to the last file
}
```

this allow us to show user such state

1. how much percentage is done, like `86% completed`
2. show how much storage was generated, lke `170gb of 256 gb was smeshed`

failed ci on win is related to github actions, not related to this pr. issue https://github.com/spacemeshos/post/issues/58
but probably it will be fixed by golang dev team
