### PR TITLE
Remove flags in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export CGO_ENABLED := 1
 include Makefile.Inc
 
 test: get-gpu-setup
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" gotestsum -- -timeout 5m -p 1 -race ./...
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" gotestsum -- -timeout 5m -p 1 -race -short ./...
 .PHONY: test
 
 compile-test: get-gpu-setup
@@ -62,7 +62,7 @@ lint-github-action: get-gpu-setup
 .PHONY: lint-github-action
 
 cover: get-gpu-setup
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 $(UNIT_TESTS)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 ./...
 .PHONY: cover
 
 staticcheck: get-gpu-setup

--- a/gpu/api_test.go
+++ b/gpu/api_test.go
@@ -1,7 +1,6 @@
 package gpu
 
 import (
-	"flag"
 	"fmt"
 	"sync"
 	"testing"
@@ -15,9 +14,6 @@ import (
 var (
 	id   = make([]byte, 32)
 	salt = make([]byte, 32)
-
-	debug = flag.Bool("debug", false, "")
-	long  = flag.Bool("long", false, "")
 )
 
 func TestCPUProviderExists(t *testing.T) {
@@ -45,9 +41,7 @@ func TestScryptPositions(t *testing.T) {
 		r.NotNil(res.Output)
 		r.False(res.Stopped)
 
-		if *debug {
-			fmt.Printf("provider: %+v, res: %+v\n", p, res)
-		}
+		t.Logf("provider: %+v, res: %+v\n", p, res)
 
 		// Assert that output content is equal between different providers.
 		if prevOutput == nil {
@@ -61,7 +55,7 @@ func TestScryptPositions(t *testing.T) {
 // TestScryptPositions_HashLenBits tests output correctness for the entire value range of HashLenBits for a specific batch size.
 func TestScryptPositions_HashLenBits(t *testing.T) {
 	r := require.New(t)
-	if !*long {
+	if testing.Short() {
 		t.Skip("long test")
 	}
 
@@ -78,9 +72,7 @@ func TestScryptPositions_HashLenBits(t *testing.T) {
 			r.NotNil(res.Output)
 			r.False(res.Stopped)
 
-			if *debug {
-				fmt.Printf("provider: %+v, len: %v, hs: %v\n", p, hashLenBits, res.HashesPerSec)
-			}
+			t.Logf("provider: %+v, len: %v, hs: %v\n", p, hashLenBits, res.HashesPerSec)
 
 			// Assert that output content is equal between different providers.
 			if prevOutput == nil {

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -1,7 +1,6 @@
 package verifying
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"testing"
@@ -19,9 +18,6 @@ import (
 var (
 	id = make([]byte, 32)
 	ch = make(proving.Challenge, 32)
-
-	debug = flag.Bool("debug", false, "")
-	long  = flag.Bool("long", false, "")
 
 	NewInitializer = initialization.NewInitializer
 	NewProver      = proving.NewProver
@@ -73,7 +69,7 @@ func TestVerify(t *testing.T) {
 //     and ensure that each one equals a single label compute (verifier).
 func TestLabelsCorrectness(t *testing.T) {
 	req := require.New(t)
-	if !*long {
+	if testing.Short() {
 		t.Skip("long test")
 	}
 
@@ -84,9 +80,7 @@ func TestLabelsCorrectness(t *testing.T) {
 	datadir := t.TempDir()
 
 	for bitsPerLabel := uint32(config.MinBitsPerLabel); bitsPerLabel <= config.MaxBitsPerLabel; bitsPerLabel++ {
-		if *debug {
-			fmt.Printf("bitsPerLabel: %v\n", bitsPerLabel)
-		}
+		t.Logf("bitsPerLabel: %v\n", bitsPerLabel)
 
 		// Write.
 		for i := 0; i < numFiles; i++ {


### PR DESCRIPTION
Instead of manually parsing flags in tests we should use built in tools like `go test -short` and the fact that (passing) tests are silent unless `go test -v` is called.

Using these two allows the removal of the `debug` and `long` flags currently present