### PR TITLE
Fix possible race in initializer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spacemeshos/bitstream v0.0.0-20221019141347-c47ad6b731c3
 	github.com/spacemeshos/go-scale v1.0.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/sync v0.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gpu/api.go
+++ b/gpu/api.go
@@ -42,7 +42,7 @@ func filterCPUProvider(providers []ComputeProvider) ComputeProvider {
 }
 
 func Benchmark(p ComputeProvider) (int, error) {
-	id := make([]byte, 32)
+	commitment := make([]byte, 32)
 	salt := make([]byte, 32)
 	hashLenBits := uint32(8)
 	startPosition := uint64(1)
@@ -51,7 +51,7 @@ func Benchmark(p ComputeProvider) (int, error) {
 		endPosition = uint64(1 << 14)
 	}
 
-	res, err := ScryptPositions(p.ID, id, salt, startPosition, endPosition, hashLenBits)
+	res, err := ScryptPositions(p.ID, commitment, salt, startPosition, endPosition, hashLenBits)
 	if err != nil {
 		return 0, err
 	}

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -47,7 +47,7 @@ func CPUProviderID() int {
 
 type Initializer struct {
 	// numLabelsWritten should be aligned by 8 bytes because it's accessed by atomics.
-	numLabelsWritten     uint64
+	numLabelsWritten     atomic.Int64
 	numLabelsWrittenChan chan uint64
 
 	cfg        Config
@@ -171,7 +171,7 @@ func (init *Initializer) SessionNumLabelsWrittenChan() <-chan uint64 {
 }
 
 func (init *Initializer) SessionNumLabelsWritten() uint64 {
-	return atomic.LoadUint64(&init.numLabelsWritten)
+	return uint64(init.numLabelsWritten.Load())
 }
 
 func (init *Initializer) Reset() error {
@@ -346,7 +346,7 @@ func (init *Initializer) initFile(computeProviderID uint, fileIndex int, numLabe
 }
 
 func (init *Initializer) updateSessionNumLabelsWritten(numLabelsWritten uint64) {
-	atomic.StoreUint64(&init.numLabelsWritten, numLabelsWritten)
+	init.numLabelsWritten.Add(int64(numLabelsWritten))
 
 	select {
 	case init.numLabelsWrittenChan <- numLabelsWritten:

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -46,7 +46,6 @@ func CPUProviderID() int {
 }
 
 type Initializer struct {
-	// numLabelsWritten should be aligned by 8 bytes because it's accessed by atomics.
 	numLabelsWritten     atomic.Int64
 	numLabelsWrittenChan chan uint64
 

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -42,8 +42,8 @@ func TestInitialize(t *testing.T) {
 	log := testLogger{t: t}
 
 	cfg, opts := getTestConfig(t)
-	id := make([]byte, 32)
-	init, err := NewInitializer(cfg, opts, id)
+	commitment := make([]byte, 32)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -62,8 +62,8 @@ func TestInitialize_Repeated(t *testing.T) {
 	log := testLogger{t: t}
 
 	cfg, opts := getTestConfig(t)
-	id := make([]byte, 32)
-	init, err := NewInitializer(cfg, opts, id)
+	commitment := make([]byte, 32)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -73,7 +73,7 @@ func TestInitialize_Repeated(t *testing.T) {
 	<-doneChan
 
 	// Initialize again using the same config & opts.
-	init, err = NewInitializer(cfg, opts, id)
+	init, err = NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -93,9 +93,9 @@ func TestInitialize_NumUnits_Increase(t *testing.T) {
 
 	cfg, opts := getTestConfig(t)
 	opts.NumFiles = 1
-	id := make([]byte, 32)
+	commitment := make([]byte, 32)
 
-	init, err := NewInitializer(cfg, opts, id)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -107,7 +107,7 @@ func TestInitialize_NumUnits_Increase(t *testing.T) {
 	// Increase `opts.NumUnits`.
 	opts.NumUnits++
 
-	init, err = NewInitializer(cfg, opts, id)
+	init, err = NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -128,9 +128,9 @@ func TestInitialize_NumUnits_Decrease(t *testing.T) {
 	cfg, opts := getTestConfig(t)
 	opts.NumUnits++
 	opts.NumFiles = 1
-	id := make([]byte, 32)
+	commitment := make([]byte, 32)
 
-	init, err := NewInitializer(cfg, opts, id)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -142,7 +142,7 @@ func TestInitialize_NumUnits_Decrease(t *testing.T) {
 	// Decrease `opts.NumUnits`.
 	opts.NumUnits--
 
-	init, err = NewInitializer(cfg, opts, id)
+	init, err = NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -163,9 +163,9 @@ func TestInitialize_NumUnits_MultipleFiles(t *testing.T) {
 	cfg, opts := getTestConfig(t)
 	opts.NumUnits++
 	opts.NumFiles = 2
-	id := make([]byte, 32)
+	commitment := make([]byte, 32)
 
-	init, err := NewInitializer(cfg, opts, id)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 
@@ -178,7 +178,7 @@ func TestInitialize_NumUnits_MultipleFiles(t *testing.T) {
 
 	// Increase `opts.NumUnits` while `opts.NumFiles` > 1.
 	opts.NumUnits = prevNumUnits + 1
-	init, err = NewInitializer(cfg, opts, id)
+	init, err = NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	err = init.Initialize()
 	cfgMissErr := &shared.ConfigMismatchError{}
@@ -187,7 +187,7 @@ func TestInitialize_NumUnits_MultipleFiles(t *testing.T) {
 
 	// Decrease `opts.NumUnits` while `opts.NumFiles` > 1.
 	opts.NumUnits = prevNumUnits - 1
-	init, err = NewInitializer(cfg, opts, id)
+	init, err = NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	err = init.Initialize()
 	r.ErrorAs(err, cfgMissErr)
@@ -202,8 +202,8 @@ func TestInitialize_MultipleFiles(t *testing.T) {
 	r := require.New(t)
 
 	cfg, opts := getTestConfig(t)
-	id := make([]byte, 32)
-	init, err := NewInitializer(cfg, opts, id)
+	commitment := make([]byte, 32)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	err = init.Initialize()
 	r.NoError(err)
@@ -219,7 +219,7 @@ func TestInitialize_MultipleFiles(t *testing.T) {
 		opts := opts
 		opts.NumFiles = numFiles
 
-		init, err := NewInitializer(cfg, opts, id)
+		init, err := NewInitializer(cfg, opts, commitment)
 		r.NoError(err)
 		err = init.Initialize()
 		r.NoError(err)
@@ -239,8 +239,8 @@ func TestNumLabelsWritten(t *testing.T) {
 	req := require.New(t)
 
 	cfg, opts := getTestConfig(t)
-	id := make([]byte, 32)
-	init, err := NewInitializer(cfg, opts, id)
+	commitment := make([]byte, 32)
+	init, err := NewInitializer(cfg, opts, commitment)
 	req.NoError(err)
 
 	// Check initial state.
@@ -263,7 +263,7 @@ func TestNumLabelsWritten(t *testing.T) {
 	req.Equal(uint64(opts.NumUnits)*cfg.LabelsPerUnit, numLabelsWritten)
 
 	// Initialize repeated, using a new instance.
-	init, err = NewInitializer(cfg, opts, id)
+	init, err = NewInitializer(cfg, opts, commitment)
 	req.NoError(err)
 	numLabelsWritten, err = init.diskState.NumLabelsWritten()
 	req.NoError(err)
@@ -283,8 +283,8 @@ func TestValidateMetadata(t *testing.T) {
 	r := require.New(t)
 
 	cfg, opts := getTestConfig(t)
-	id := make([]byte, 32)
-	init, err := NewInitializer(cfg, opts, id)
+	commitment := make([]byte, 32)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 
 	m, err := init.loadMetadata()
@@ -299,9 +299,9 @@ func TestValidateMetadata(t *testing.T) {
 	r.NoError(err)
 
 	// Attempt to initialize with different `Commitment`.
-	newID := make([]byte, 32)
-	newID[0] = newID[0] + 1
-	init, err = NewInitializer(cfg, opts, newID)
+	newCommitment := make([]byte, 32)
+	newCommitment[0] = newCommitment[0] + 1
+	init, err = NewInitializer(cfg, opts, newCommitment)
 	r.NoError(err)
 	err = init.Initialize()
 	errConfigMismatch, ok := err.(ConfigMismatchError)
@@ -311,7 +311,7 @@ func TestValidateMetadata(t *testing.T) {
 	// Attempt to initialize with different `cfg.BitsPerLabel`.
 	newCfg := cfg
 	newCfg.BitsPerLabel = cfg.BitsPerLabel + 1
-	init, err = NewInitializer(newCfg, opts, id)
+	init, err = NewInitializer(newCfg, opts, commitment)
 	r.NoError(err)
 	err = init.Initialize()
 	errConfigMismatch, ok = err.(ConfigMismatchError)
@@ -321,7 +321,7 @@ func TestValidateMetadata(t *testing.T) {
 	// Attempt to initialize with different `opts.NumFiles`.
 	newOpts := opts
 	newOpts.NumFiles = 4
-	init, err = NewInitializer(cfg, newOpts, id)
+	init, err = NewInitializer(cfg, newOpts, commitment)
 	r.NoError(err)
 	err = init.Initialize()
 	errConfigMismatch, ok = err.(ConfigMismatchError)
@@ -331,7 +331,7 @@ func TestValidateMetadata(t *testing.T) {
 	// Attempt to initialize with different `opts.NumUnits` while `opts.NumFiles` > 1.
 	newOpts = opts
 	newOpts.NumUnits++
-	init, err = NewInitializer(cfg, newOpts, id)
+	init, err = NewInitializer(cfg, newOpts, commitment)
 	r.NoError(err)
 	err = init.Initialize()
 	errConfigMismatch, ok = err.(ConfigMismatchError)
@@ -349,9 +349,9 @@ func TestStop(t *testing.T) {
 
 	cfg, opts := getTestConfig(t)
 	opts.NumUnits = 10
-	id := make([]byte, 32)
+	commitment := make([]byte, 32)
 
-	init, err := NewInitializer(cfg, opts, id)
+	init, err := NewInitializer(cfg, opts, commitment)
 	r.NoError(err)
 	init.SetLogger(log)
 

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -76,7 +76,7 @@ func TestLabelsCorrectness(t *testing.T) {
 	numFiles := 2
 	numFileBatches := 2
 	batchSize := 256
-	id := make([]byte, 32)
+	commitment := make([]byte, 32)
 	datadir := t.TempDir()
 
 	for bitsPerLabel := uint32(config.MinBitsPerLabel); bitsPerLabel <= config.MaxBitsPerLabel; bitsPerLabel++ {
@@ -91,7 +91,7 @@ func TestLabelsCorrectness(t *testing.T) {
 				startPosition := uint64(numBatch * batchSize)
 				endPosition := startPosition + uint64(batchSize) - 1
 
-				labels, err := oracle.WorkOracle(uint(CPUProviderID()), id, startPosition, endPosition, bitsPerLabel)
+				labels, err := oracle.WorkOracle(uint(CPUProviderID()), commitment, startPosition, endPosition, bitsPerLabel)
 				req.NoError(err)
 				err = writer.Write(labels)
 				req.NoError(err)
@@ -117,7 +117,7 @@ func TestLabelsCorrectness(t *testing.T) {
 			}
 
 			// Verify correctness.
-			labelCompute := oracle.WorkOracleOne(id, position, bitsPerLabel)
+			labelCompute := oracle.WorkOracleOne(commitment, position, bitsPerLabel)
 			req.Equal(labelCompute, label, fmt.Sprintf("position: %v, bitsPerLabel: %v", position, bitsPerLabel))
 
 			position++


### PR DESCRIPTION
This fixes an issue in `Initialize()` where `numLabelsWrittenChan` can be set by two goroutines without protection through a mutex:

- `defer` in `Initialize()` is not protected
- `SessionNumLabelsWrittenChan` is possibly called by a different go routine

leading to a possible race. Furthermore the returned channel from `SessionNumLabelsWrittenChan` might never be written to (if called after `Initialize()` returns). Tests occasionally time out for this reason.

Additionally `numLabelsWrittenChan` is a buffered channel to which a blocking send happens in `updateSessionNumLabelsWritten`. This causes the `Initializer` to halt until another goroutine starts reading from the channel. To fix this issue `Initializer` will now skip writing to `numLabelsWrittenChan` if no reader is waiting for updates.