### PR TITLE
Fix api.h not found in projects using library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export CGO_ENABLED := 1
-export CGO_CFLAGS := "-I$(BIN_DIR)"
 include Makefile.Inc
 
 test: get-gpu-setup

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export CGO_ENABLED := 1
+export CGO_CFLAGS := "-I$(BIN_DIR)"
 include Makefile.Inc
 
 test: get-gpu-setup

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -2,6 +2,7 @@ PROJ_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 BIN_DIR ?= $(PROJ_DIR)build/
 
 export CGO_LDFLAGS := -L$(BIN_DIR)
+export CPATH := $(PROJ_DIR)build/
 export GOOS
 export GOARCH
 export GOARM
@@ -48,7 +49,7 @@ else
 endif
 
 ifneq ($(VERBOSE),)
-  $(info "OS: $(OS), HOST_OS: $(HOST_OS), GOOS: $(GOOS), GOARCH: $(GOARH), BIN_DIR: $(BIN_DIR), platform: $(platform)")
+  $(info "OS: $(OS), HOST_OS: $(HOST_OS), GOOS: $(GOOS), GOARCH: $(GOARCH), BIN_DIR: $(BIN_DIR), platform: $(platform)")
 endif
 
 GPU_SETUP_REV = 0.1.26

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -71,9 +71,6 @@ $(BINDIR_GPU_SETUP_LIBS): $(PROJ_DIR)$(GPU_SETUP_ZIP)
 	touch $@
 $(PROJ_DIR)$(GPU_SETUP_ZIP):
 	curl -L $(GPU_SETUP_URL_ZIP) -o $(PROJ_DIR)$(GPU_SETUP_ZIP)
-$(BIN_DIR)$(BINARY):
-	mkdir -p $(dir $@)
-	go build ${LDFLAGS} -o $(BIN_DIR)$(BINARY)
 
 get-gpu-setup: $(PROJ_DIR)$(GPU_SETUP_ZIP) $(BINDIR_GPU_SETUP_LIBS)
 .PHONY: get-gpu-setup

--- a/gpu/bridge.go
+++ b/gpu/bridge.go
@@ -2,7 +2,7 @@ package gpu
 
 // #cgo LDFLAGS: -lgpu-setup
 //
-// #include "../build/api.h"
+// #include <api.h>
 // #include <stdlib.h>
 import "C"
 


### PR DESCRIPTION
To make `api.h` visible to the C compiler in go projects using `post`. We need to include `api.h` from the global include path instead of relative from the source.

This way a go project using `post` can set `CPATH` to indicate to the compiler where to look for `api.h`.