### PR TITLE
Fix incorrect count of labels written

### DIFF
--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -345,7 +345,7 @@ func (init *Initializer) initFile(computeProviderID uint, fileIndex int, numLabe
 }
 
 func (init *Initializer) updateSessionNumLabelsWritten(numLabelsWritten uint64) {
-	init.numLabelsWritten.Add(int64(numLabelsWritten))
+	init.numLabelsWritten.Store(int64(numLabelsWritten))
 
 	select {
 	case init.numLabelsWrittenChan <- numLabelsWritten:

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -46,7 +46,7 @@ func CPUProviderID() int {
 }
 
 type Initializer struct {
-	numLabelsWritten     atomic.Int64
+	numLabelsWritten     atomic.Uint64
 	numLabelsWrittenChan chan uint64
 
 	cfg        Config
@@ -170,7 +170,7 @@ func (init *Initializer) SessionNumLabelsWrittenChan() <-chan uint64 {
 }
 
 func (init *Initializer) SessionNumLabelsWritten() uint64 {
-	return uint64(init.numLabelsWritten.Load())
+	return init.numLabelsWritten.Load()
 }
 
 func (init *Initializer) Reset() error {
@@ -345,7 +345,7 @@ func (init *Initializer) initFile(computeProviderID uint, fileIndex int, numLabe
 }
 
 func (init *Initializer) updateSessionNumLabelsWritten(numLabelsWritten uint64) {
-	init.numLabelsWritten.Store(int64(numLabelsWritten))
+	init.numLabelsWritten.Store(numLabelsWritten)
 
 	select {
 	case init.numLabelsWrittenChan <- numLabelsWritten:

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -50,8 +50,8 @@ func TestInitialize(t *testing.T) {
 	init.SetLogger(log)
 
 	var eg errgroup.Group
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Cleanup.
@@ -69,8 +69,8 @@ func TestInitialize_Repeated(t *testing.T) {
 	init.SetLogger(log)
 
 	var eg errgroup.Group
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Initialize again using the same config & opts.
@@ -78,8 +78,8 @@ func TestInitialize_Repeated(t *testing.T) {
 	r.NoError(err)
 	init.SetLogger(log)
 
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Cleanup.
@@ -99,8 +99,8 @@ func TestInitialize_NumUnits_Increase(t *testing.T) {
 	init.SetLogger(log)
 
 	var eg errgroup.Group
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Increase `opts.NumUnits`.
@@ -110,8 +110,8 @@ func TestInitialize_NumUnits_Increase(t *testing.T) {
 	r.NoError(err)
 	init.SetLogger(log)
 
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Cleanup.
@@ -132,8 +132,8 @@ func TestInitialize_NumUnits_Decrease(t *testing.T) {
 	init.SetLogger(log)
 
 	var eg errgroup.Group
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Decrease `opts.NumUnits`.
@@ -143,8 +143,8 @@ func TestInitialize_NumUnits_Decrease(t *testing.T) {
 	r.NoError(err)
 	init.SetLogger(log)
 
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Cleanup.
@@ -165,8 +165,8 @@ func TestInitialize_NumUnits_MultipleFiles(t *testing.T) {
 	init.SetLogger(log)
 
 	var eg errgroup.Group
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	prevNumUnits := opts.NumUnits
@@ -372,8 +372,8 @@ func TestStop(t *testing.T) {
 	r.NoError(eg.Wait())
 
 	// Continue the initialization to completion.
-	eg.Go(init.Initialize)
 	eg.Go(assertNumLabelsWrittenChan(init, t))
+	r.NoError(init.Initialize())
 	r.NoError(eg.Wait())
 
 	// Cleanup.

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -445,10 +445,14 @@ func assertNumLabelsWrittenChan(init *Initializer, t *testing.T) func() error {
 	return func() error {
 		// hack to avoid receiving a nil channel from SessionNumLabelsWrittenChan()
 		// TODO (mafa): for a proper fix see https://github.com/spacemeshos/post/issues/78
-		time.Sleep(10 * time.Millisecond)
+		var labelsChan <-chan uint64
+		assert.Eventually(t, func() bool {
+			labelsChan = init.SessionNumLabelsWrittenChan()
+			return labelsChan != nil
+		}, time.Second, time.Millisecond)
 
 		var prev uint64
-		for p := range init.SessionNumLabelsWrittenChan() {
+		for p := range labelsChan {
 			assert.Less(t, prev, p)
 			prev = p
 			t.Logf("num labels written: %v\n", p)


### PR DESCRIPTION
This is a fix for a bug that was introduced in this commit: https://github.com/spacemeshos/post/commit/55a0a5115ea2f606816a05523fde4b90075964df#diff-6682f153c20b292747e05c02ab1907c2d29c9888a086349448302f85f31ee6b9L348-R349

Instead of updating the number of labels written, the new value is incorrectly added to the current value, causing `Initializer` to report an incorrect number of the total.