### PR TITLE
Refactor initializer to be simpler to use and race free

### DIFF
--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -163,12 +163,6 @@ func (init *Initializer) Stop() error {
 	return nil
 }
 
-func (init *Initializer) SessionNumLabelsWrittenChan() <-chan uint64 {
-	init.mtx.RLock()
-	defer init.mtx.RUnlock()
-	return init.numLabelsWrittenChan
-}
-
 func (init *Initializer) SessionNumLabelsWritten() uint64 {
 	return init.numLabelsWritten.Load()
 }

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -188,12 +188,10 @@ func (init *Initializer) SessionNumLabelsWritten() uint64 {
 }
 
 func (init *Initializer) Reset() error {
-	switch init.Status() {
-	case StatusInitializing:
+	if !init.mtx.TryLock() {
 		return ErrCannotResetWhileInitializing
-	case StatusError:
-		return fmt.Errorf("cannot determine status of initialization")
 	}
+	defer init.mtx.Unlock()
 
 	files, err := os.ReadDir(init.opts.DataDir)
 	if err != nil {

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -68,10 +68,7 @@ func (opts *initializeOption) verify() error {
 		return errors.New("no init options provided")
 	}
 
-	if err := config.Validate(*opts.cfg, *opts.initOpts); err != nil {
-		return err
-	}
-	return nil
+	return config.Validate(*opts.cfg, *opts.initOpts)
 }
 
 type initializeOptionFunc func(*initializeOption) error

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -231,7 +231,6 @@ func (init *Initializer) SessionNumLabelsWritten() uint64 {
 }
 
 func (init *Initializer) Reset() error {
-
 	switch init.Status() {
 	case StatusInitializing:
 		return ErrCannotResetWhileInitializing

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -52,28 +52,6 @@ func CPUProviderID() int {
 	return gpu.CPUProviderID()
 }
 
-func RemoveDataFiles(dataDir string) error {
-	files, err := os.ReadDir(dataDir)
-	if err != nil {
-		return err
-	}
-
-	for _, file := range files {
-		info, err := file.Info()
-		if err != nil {
-			continue
-		}
-		if shared.IsInitFile(info) || file.Name() == metadataFileName {
-			path := filepath.Join(dataDir, file.Name())
-			if err := os.Remove(path); err != nil {
-				return fmt.Errorf("failed to delete file (%v): %w", path, err)
-			}
-		}
-	}
-
-	return nil
-}
-
 type initializeOption struct {
 	commitment []byte
 	cfg        *Config

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -451,7 +451,7 @@ func TestStop(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			timer := time.NewTimer(50 * time.Millisecond)
+			timer := time.NewTicker(50 * time.Millisecond)
 			defer timer.Stop()
 
 			for {


### PR DESCRIPTION
This fixes #78 by slimming down the `Initializer` and removing asynchronous calls. This should also fix data race issues we have with the component.

I did not remove the `Reset` method, since it is used by `go-spacemesh` and factoring it out would have been more effort than what I think is worth at the moment.

Now `Initializer::Initialize()` takes a context that can be canceled by the caller to stop the initialization early. `Initializer::Stop()` was removed as it is not needed any more and instead of having multiple methods that report some kind of state (`Started()`, `Completed()`, etc.) there is now only one method called `Status()` that reports the state of the initialization.

For integration into go-spacemesh see: https://github.com/spacemeshos/go-spacemesh/pull/3715