### PR TITLE
Make PowDifficulty easier

### DIFF
--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -41,6 +41,8 @@ var (
 	ErrAlreadyInitializing          = errors.New("already initializing")
 	ErrCannotResetWhileInitializing = errors.New("cannot reset while initializing")
 	ErrStateMetadataFileMissing     = errors.New("metadata file is missing")
+
+	powDifficultyFunc = shared.PowDifficulty
 )
 
 // Providers returns a list of available compute providers.
@@ -213,7 +215,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 
 	numLabels := uint64(init.opts.NumUnits) * uint64(init.cfg.LabelsPerUnit)
 	fileNumLabels := numLabels / uint64(init.opts.NumFiles)
-	difficulty := shared.PowDifficulty(numLabels)
+	difficulty := powDifficultyFunc(numLabels)
 	batchSize := uint64(config.DefaultComputeBatchSize)
 
 	init.logger.Info("initialization: starting to write %v file(s); number of units: %v, number of labels per unit: %v, number of bits per label: %v, datadir: %v",

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -46,12 +46,12 @@ func ProvingDifficulty(numLabels uint64, k1 uint64) uint64 {
 // approaches ~ 99.97% the bigger numLabels gets. Within 1.15 * numLabels the probability
 // approaches 99.99% of finding at least one label below the difficulty threshold.
 func PowDifficulty(numLabels uint64) []byte {
-	difficulty := make([]byte, 33)
-	difficulty[0] = 0x01
-	x := new(big.Int).SetBytes(difficulty)
+	x := new(big.Int).Lsh(big.NewInt(1), 256)
 	x.Div(x, big.NewInt(int64(numLabels)))
-	x.Lsh(x, 3) // x << 3 == x * 2^3 == x * 8
-	return x.FillBytes(difficulty[1:])
+	x.Lsh(x, 3) // reduce difficulty by a factor of 8
+
+	difficulty := make([]byte, 32)
+	return x.FillBytes(difficulty)
 }
 
 func Uint64MulOverflow(a, b uint64) bool {

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -50,7 +50,7 @@ func PowDifficulty(numLabels uint64) []byte {
 	difficulty[0] = 0x01
 	x := new(big.Int).SetBytes(difficulty)
 	x.Div(x, big.NewInt(int64(numLabels)))
-	x.Mul(x, big.NewInt(8))
+	x.Lsh(x, 3) // x << 3 == x * 2^3 == x * 8
 	return x.FillBytes(difficulty[1:])
 }
 

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -37,18 +37,20 @@ func ProvingDifficulty(numLabels uint64, k1 uint64) uint64 {
 }
 
 // PowDifficulty returns the target difficulty of finding a nonce in `numLabels` labels.
-// It is calculated such that one computed label is expected to be below the difficulty threshold.
-// The difficulty is calculated as follows:
+// It is calculated such that a high percentage of smeshers find at least one computed label
+// below the difficulty threshold. The difficulty is calculated as follows:
 //
-//	difficulty = 2^256 / numLabels
+//	difficulty = 8 * 2^256 / numLabels
 //
-// TODO(mafa): this difficulty calculation is unfit. There is only a ~ 63% chance to find a nonce
-// in the first `numLabels`	labels and only a ~ 90% chance to find a nonce in the first `2*numLabels` labels.
+// The probability of finding a label below the difficulty threshold within numLabels
+// approaches ~ 99.97% the bigger numLabels gets. Within 1.15 * numLabels the probability
+// approaches 99.99% of finding at least one label below the difficulty threshold.
 func PowDifficulty(numLabels uint64) []byte {
 	difficulty := make([]byte, 33)
 	difficulty[0] = 0x01
 	x := new(big.Int).SetBytes(difficulty)
 	x.Div(x, big.NewInt(int64(numLabels)))
+	x.Mul(x, big.NewInt(8))
 	return x.FillBytes(difficulty[1:])
 }
 


### PR DESCRIPTION
The current difficulty function for finding a nonce to be used for POPS-VRF is not a good fit. With it more than 1/3 of smeshers are expected to continue initialization when their PoST has been filled.

This reduces the difficulty of finding a nonce such that 99.97% of all smeshers are expected to find at least one index that satisfies the difficulty during initialization. Only 0.01% of smeshers are expected to do check more than 115% of the labels required for PoST initialization with this difficulty function.