### PR TITLE
Initializer has correct state on New

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,7 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -259,9 +259,6 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	}
 
 	// continue searching for a nonce
-	// TODO(mafa): PM-195 depending on the difficulty function this can take a VERY long time, with the current difficulty function
-	// ~ 37% of all smeshers won't find a nonce while computing leaves
-	// ~  2% of all smeshers won't find a nonce even after checking 4x numLabels
 	defer init.saveMetadata()
 	for i := *init.lastPosition.Load(); i < math.MaxUint64; i += batchSize {
 		lastPos := i

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -306,6 +306,10 @@ func (init *Initializer) Nonce() *uint64 {
 	return init.nonce.Load()
 }
 
+func (init *Initializer) CommitmentAtxId() []byte {
+	return init.commitmentAtxId
+}
+
 func (init *Initializer) Reset() error {
 	if !init.mtx.TryLock() {
 		return ErrCannotResetWhileInitializing

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -306,10 +306,6 @@ func (init *Initializer) Nonce() *uint64 {
 	return init.nonce.Load()
 }
 
-func (init *Initializer) CommitmentAtxId() []byte {
-	return init.commitmentAtxId
-}
-
 func (init *Initializer) Reset() error {
 	if !init.mtx.TryLock() {
 		return ErrCannotResetWhileInitializing

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -67,9 +67,14 @@ func TestInitialize(t *testing.T) {
 	}
 	r.Equal(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, init.NumLabelsWritten())
 
-	m, err := LoadMetadata(opts.DataDir)
-	r.NoError(err)
-	r.NoError(verifying.VerifyPow(m))
+	m := &shared.VRFNonceMetadata{
+		NodeId:          nodeId,
+		CommitmentAtxId: commitmentAtxId,
+		NumUnits:        opts.NumUnits,
+		BitsPerLabel:    cfg.BitsPerLabel,
+		LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+	}
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m))
 }
 
 func TestInitialize_PowOutOfRange(t *testing.T) {
@@ -108,12 +113,17 @@ func TestInitialize_PowOutOfRange(t *testing.T) {
 	r.NoError(init.Initialize(context.Background()))
 	r.Equal(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, init.NumLabelsWritten())
 
-	m, err := LoadMetadata(opts.DataDir)
-	r.NoError(err)
-	r.NoError(verifying.VerifyPow(m))
+	m := &shared.VRFNonceMetadata{
+		NodeId:          nodeId,
+		CommitmentAtxId: commitmentAtxId,
+		NumUnits:        opts.NumUnits,
+		BitsPerLabel:    cfg.BitsPerLabel,
+		LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+	}
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m))
 
 	// check that the found nonce is outside of the range for calculating labels
-	r.Less(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, *m.Nonce)
+	r.Less(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, *init.Nonce())
 }
 
 func TestInitialize_ContinueWithLastPos(t *testing.T) {
@@ -140,12 +150,17 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 	r.NoError(init.Initialize(context.Background()))
 	r.Equal(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, init.NumLabelsWritten())
 
-	m, err := LoadMetadata(opts.DataDir)
-	r.NoError(err)
-	r.NoError(verifying.VerifyPow(m))
+	meta := &shared.VRFNonceMetadata{
+		NodeId:          nodeId,
+		CommitmentAtxId: commitmentAtxId,
+		NumUnits:        opts.NumUnits,
+		BitsPerLabel:    cfg.BitsPerLabel,
+		LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+	}
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta))
 
 	// trying again returns same nonce
-	origNonce := *m.Nonce
+	origNonce := *init.Nonce()
 	init, err = NewInitializer(
 		WithNodeId(nodeId),
 		WithCommitmentAtxId(commitmentAtxId),
@@ -158,7 +173,7 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 	r.NoError(init.Initialize(context.Background()))
 	r.Equal(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, init.NumLabelsWritten())
 
-	m, err = LoadMetadata(opts.DataDir)
+	m, err := LoadMetadata(opts.DataDir)
 	r.NoError(err)
 	r.Equal(origNonce, *m.Nonce)
 	r.Nil(m.LastPosition)
@@ -205,9 +220,16 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 	r.NotNil(m.Nonce)
 	r.NotNil(m.LastPosition)
 	r.LessOrEqual(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, *m.LastPosition)
-
 	r.LessOrEqual(uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit, *m.Nonce)
-	r.NoError(verifying.VerifyPow(m))
+
+	meta = &shared.VRFNonceMetadata{
+		NodeId:          nodeId,
+		CommitmentAtxId: commitmentAtxId,
+		NumUnits:        opts.NumUnits,
+		BitsPerLabel:    cfg.BitsPerLabel,
+		LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+	}
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta))
 
 	// lastPos sets lower bound for searching for nonce if none was found
 	lastPos := *m.Nonce + 10
@@ -234,7 +256,15 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 	r.LessOrEqual(lastPos, *m.LastPosition)
 
 	r.Less(lastPos, *m.Nonce)
-	r.NoError(verifying.VerifyPow(m))
+
+	meta = &shared.VRFNonceMetadata{
+		NodeId:          nodeId,
+		CommitmentAtxId: commitmentAtxId,
+		NumUnits:        opts.NumUnits,
+		BitsPerLabel:    cfg.BitsPerLabel,
+		LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+	}
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta))
 }
 
 func TestReset_WhileInitializing(t *testing.T) {
@@ -521,9 +551,14 @@ func TestInitialize_MultipleFiles(t *testing.T) {
 	oneFileData, err := initData(opts.DataDir, uint(cfg.BitsPerLabel))
 	r.NoError(err)
 
-	m, err := LoadMetadata(opts.DataDir)
-	r.NoError(err)
-	r.NoError(verifying.VerifyPow(m))
+	m := &shared.VRFNonceMetadata{
+		NodeId:          nodeId,
+		CommitmentAtxId: commitmentAtxId,
+		NumUnits:        opts.NumUnits,
+		BitsPerLabel:    cfg.BitsPerLabel,
+		LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+	}
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m))
 
 	// TODO(mafa): since we are not looking for the absolute lowest nonce, we can't guarantee that the nonce will be the same.
 	// see also https://github.com/spacemeshos/post/issues/90
@@ -551,9 +586,14 @@ func TestInitialize_MultipleFiles(t *testing.T) {
 
 			r.Equal(multipleFilesData, oneFileData)
 
-			m, err := LoadMetadata(opts.DataDir)
-			r.NoError(err)
-			r.NoError(verifying.VerifyPow(m))
+			m := &shared.VRFNonceMetadata{
+				NodeId:          nodeId,
+				CommitmentAtxId: commitmentAtxId,
+				NumUnits:        opts.NumUnits,
+				BitsPerLabel:    cfg.BitsPerLabel,
+				LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+			}
+			r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m))
 
 			// TODO(mafa): see above
 			// r.Equal(oneFileNonce, *init.Nonce())

--- a/shared/proof.go
+++ b/shared/proof.go
@@ -16,3 +16,14 @@ type ProofMetadata struct {
 	K1            uint32
 	K2            uint32
 }
+
+type VRFNonce uint64
+
+type VRFNonceMetadata struct {
+	NodeId          []byte
+	CommitmentAtxId []byte
+
+	NumUnits      uint32
+	BitsPerLabel  uint8
+	LabelsPerUnit uint64
+}

--- a/verifying/verifying.go
+++ b/verifying/verifying.go
@@ -21,10 +21,10 @@ var (
 	UInt64LE   = shared.UInt64LE
 )
 
-// VerifyPow ensures the validity of a nonce for a given node.
+// VerifyVRFNonce ensures the validity of a nonce for a given node.
 // AtxId is the id of the ATX that was selected by the node for its commitment.
-func VerifyPow(m *shared.PostMetadata) error {
-	if m.Nonce == nil {
+func VerifyVRFNonce(nonce *uint64, m *shared.VRFNonceMetadata) error {
+	if nonce == nil {
 		return errors.New("invalid `nonce` value; expected: non-nil, given: nil")
 	}
 
@@ -42,7 +42,7 @@ func VerifyPow(m *shared.PostMetadata) error {
 
 	res, err := WorkOracle(
 		oracle.WithCommitment(oracle.CommitmentBytes(m.NodeId, m.CommitmentAtxId)),
-		oracle.WithPosition(*m.Nonce),
+		oracle.WithPosition(*nonce),
 		oracle.WithBitsPerLabel(uint32(m.BitsPerLabel)*32),
 	)
 	if err != nil {

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -73,9 +73,14 @@ func TestVerifyPow(t *testing.T) {
 	r.NoError(err)
 	r.NoError(init.Initialize(context.Background()))
 
-	m, err := initialization.LoadMetadata(opts.DataDir)
-	r.NoError(err)
-	r.NoError(VerifyPow(m))
+	m := &shared.VRFNonceMetadata{
+		NodeId:          nodeId,
+		CommitmentAtxId: commitmentAtxId,
+		NumUnits:        opts.NumUnits,
+		BitsPerLabel:    cfg.BitsPerLabel,
+		LabelsPerUnit:   uint64(opts.NumUnits) * cfg.LabelsPerUnit,
+	}
+	r.NoError(VerifyVRFNonce(init.Nonce(), m))
 }
 
 // TestLabelsCorrectness tests, for variation of label sizes, the correctness of


### PR DESCRIPTION
Instead of evaluating the metadata available in the `dataDir` on a call to `Initialize()`, we should already evaluate it when the Initializer is created with `NewInitializer()`.

This allows for code simplifications in https://github.com/spacemeshos/go-spacemesh/pull/3788/