### PR TITLE
Adjusted default config values for modern hardware

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ type InitOpts struct {
 	ComputeProviderID int
 	Throttle          bool
 	Scrypt            ScryptParams
+	ComputeBatchSize  uint64
 }
 
 type ScryptParams struct {
@@ -118,6 +119,7 @@ func DefaultInitOpts() InitOpts {
 		ComputeProviderID: BestProviderID,
 		Throttle:          false,
 		Scrypt:            DefaultLabelParams(),
+		ComputeBatchSize:  DefaultComputeBatchSize,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,13 +14,13 @@ const (
 
 	// DefaultComputeBatchSize value must be divisible by 8, to guarantee that writing to disk
 	// and file truncating is byte-granular.
-	DefaultComputeBatchSize = 1 << 14
+	DefaultComputeBatchSize = 1 << 20
 
 	MinBitsPerLabel = 1
 	MaxBitsPerLabel = 256
 	BitsPerLabel    = 8 * 16
 
-	defaultMaxNumUnits = 10
+	defaultMaxNumUnits = 100
 	defaultMinNumUnits = 1
 
 	KiB = 1024

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -246,7 +246,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 
 	numLabels := uint64(init.opts.NumUnits) * init.cfg.LabelsPerUnit
 	difficulty := init.powDifficultyFunc(numLabels)
-	batchSize := uint64(config.DefaultComputeBatchSize)
+	batchSize := init.opts.ComputeBatchSize
 
 	for i := 0; i < int(layout.NumFiles); i++ {
 		fileOffset := uint64(i) * layout.FileNumLabels

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -778,10 +778,11 @@ func TestStop(t *testing.T) {
 	cfg.LabelsPerUnit = 1 << 12
 
 	opts := config.DefaultInitOpts()
-	opts.Scrypt.N = 512
+	opts.Scrypt.N = 2
 	opts.DataDir = t.TempDir()
 	opts.NumUnits = 10
 	opts.ComputeProviderID = int(CPUProviderID())
+	opts.ComputeBatchSize = 1 << 10
 
 	init, err := NewInitializer(
 		WithNodeId(nodeId),

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -43,6 +43,7 @@ func TestInitialize(t *testing.T) {
 	opts.DataDir = t.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
 	opts.ComputeProviderID = int(CPUProviderID())
+	opts.Scrypt.N = 16
 
 	init, err := NewInitializer(
 		WithNodeId(nodeId),
@@ -71,7 +72,7 @@ func TestInitialize(t *testing.T) {
 		NumUnits:        opts.NumUnits,
 		LabelsPerUnit:   cfg.LabelsPerUnit,
 	}
-	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m))
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m, verifying.WithLabelScryptParams(opts.Scrypt)))
 }
 
 func TestMaxFileSize(t *testing.T) {
@@ -109,9 +110,10 @@ func TestInitialize_PowOutOfRange(t *testing.T) {
 	opts.DataDir = t.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
 	opts.ComputeProviderID = int(CPUProviderID())
+	opts.Scrypt.N = 16
 
 	// nodeId where no label in the first uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit satisfies the PoW requirement.
-	nodeId, err := hex.DecodeString("54fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649")
+	nodeId, err := hex.DecodeString("57fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649")
 	r.NoError(err)
 
 	init, err := NewInitializer(
@@ -140,7 +142,7 @@ func TestInitialize_PowOutOfRange(t *testing.T) {
 		NumUnits:        opts.NumUnits,
 		LabelsPerUnit:   cfg.LabelsPerUnit,
 	}
-	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m))
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), m, verifying.WithLabelScryptParams(opts.Scrypt)))
 
 	// check that the found nonce is outside of the range for calculating labels
 	r.GreaterOrEqual(*init.Nonce(), uint64(cfg.MinNumUnits)*cfg.LabelsPerUnit)
@@ -156,6 +158,7 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 	opts.DataDir = t.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
 	opts.ComputeProviderID = int(CPUProviderID())
+	opts.Scrypt.N = 16
 
 	init, err := NewInitializer(
 		WithNodeId(nodeId),
@@ -175,7 +178,7 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 		NumUnits:        opts.NumUnits,
 		LabelsPerUnit:   cfg.LabelsPerUnit,
 	}
-	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta))
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta, verifying.WithLabelScryptParams(opts.Scrypt)))
 
 	// trying again returns same nonce
 	origNonce := *init.Nonce()
@@ -246,7 +249,7 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 		NumUnits:        opts.NumUnits,
 		LabelsPerUnit:   cfg.LabelsPerUnit,
 	}
-	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta))
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta, verifying.WithLabelScryptParams(opts.Scrypt)))
 
 	// lastPos sets lower bound for searching for nonce if none was found
 	lastPos := *m.Nonce + 10
@@ -280,7 +283,7 @@ func TestInitialize_ContinueWithLastPos(t *testing.T) {
 		NumUnits:        opts.NumUnits,
 		LabelsPerUnit:   cfg.LabelsPerUnit,
 	}
-	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta))
+	r.NoError(verifying.VerifyVRFNonce(init.Nonce(), meta, verifying.WithLabelScryptParams(opts.Scrypt)))
 }
 
 func TestReset_WhileInitializing(t *testing.T) {
@@ -294,6 +297,7 @@ func TestReset_WhileInitializing(t *testing.T) {
 	opts.DataDir = t.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
 	opts.ComputeProviderID = int(CPUProviderID())
+	opts.ComputeBatchSize = 1 << 14
 
 	init, err := NewInitializer(
 		WithNodeId(nodeId),
@@ -307,7 +311,7 @@ func TestReset_WhileInitializing(t *testing.T) {
 	{
 		var eg errgroup.Group
 		eg.Go(func() error {
-			r.Eventually(func() bool { return init.NumLabelsWritten() > 0 }, 5*time.Second, 50*time.Millisecond)
+			r.Eventually(func() bool { return init.NumLabelsWritten() > 0 }, 5*time.Second, 10*time.Millisecond)
 			r.ErrorIs(init.Reset(), ErrCannotResetWhileInitializing)
 			return nil
 		})
@@ -778,7 +782,7 @@ func TestStop(t *testing.T) {
 	cfg.LabelsPerUnit = 1 << 12
 
 	opts := config.DefaultInitOpts()
-	opts.Scrypt.N = 2
+	opts.Scrypt.N = 16
 	opts.DataDir = t.TempDir()
 	opts.NumUnits = 10
 	opts.ComputeProviderID = int(CPUProviderID())

--- a/proving/proving_test.go
+++ b/proving/proving_test.go
@@ -24,7 +24,7 @@ func getTestConfig(tb testing.TB) (config.Config, config.InitOpts) {
 	opts.DataDir = tb.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
 	opts.ComputeProviderID = int(initialization.CPUProviderID())
-
+	opts.ComputeBatchSize = 1 << 14
 	return cfg, opts
 }
 

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -22,7 +22,7 @@ func getTestConfig(tb testing.TB) (config.Config, config.InitOpts) {
 	opts.DataDir = tb.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
 	opts.ComputeProviderID = int(initialization.CPUProviderID())
-
+	opts.ComputeBatchSize = 1 << 14
 	return cfg, opts
 }
 


### PR DESCRIPTION
`1 << 20` seems to be the most optimal for AMD cards
Nvidia would need `1 << 22` but that can be done later.