### PR TITLE
Add validation for compute batch size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,6 @@ import (
 const (
 	DefaultDataDirName = "data"
 
-	// DefaultComputeBatchSize value must be divisible by 8, to guarantee that writing to disk
-	// and file truncating is byte-granular.
 	DefaultComputeBatchSize = 1 << 20
 
 	MinBitsPerLabel = 1
@@ -71,7 +69,8 @@ type InitOpts struct {
 	ComputeProviderID int
 	Throttle          bool
 	Scrypt            ScryptParams
-	ComputeBatchSize  uint64
+	// ComputeBatchSize must be greater than 0
+	ComputeBatchSize uint64
 }
 
 type ScryptParams struct {
@@ -136,8 +135,8 @@ func Validate(cfg Config, opts InitOpts) error {
 		return fmt.Errorf("invalid `opts.MaxFileSize`; expected: >= %d, given: %d", minFileSize, opts.MaxFileSize)
 	}
 
-	if opts.ComputeBatchSize == 0 || opts.ComputeBatchSize%8 != 0 {
-		return fmt.Errorf("invalid `opts.ComputeBatchSize` expected: > 0 and divisible by 8, given: %d", opts.ComputeBatchSize)
+	if opts.ComputeBatchSize == 0 {
+		return fmt.Errorf("invalid `opts.ComputeBatchSize` expected: > 0, given: %d", opts.ComputeBatchSize)
 	}
 
 	if res := shared.Uint64MulOverflow(cfg.LabelsPerUnit, uint64(opts.NumUnits)); res {

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,10 @@ func Validate(cfg Config, opts InitOpts) error {
 		return fmt.Errorf("invalid `opts.MaxFileSize`; expected: >= %d, given: %d", minFileSize, opts.MaxFileSize)
 	}
 
+	if opts.ComputeBatchSize == 0 || opts.ComputeBatchSize%8 != 0 {
+		return fmt.Errorf("invalid `opts.ComputeBatchSize` expected: > 0 and divisible by 8, given: %d", opts.ComputeBatchSize)
+	}
+
 	if res := shared.Uint64MulOverflow(cfg.LabelsPerUnit, uint64(opts.NumUnits)); res {
 		return fmt.Errorf("uint64 overflow: `cfg.LabelsPerUnit` (%v) * `opts.NumUnits` (%v) exceeds the range allowed by uint64",
 			cfg.LabelsPerUnit, opts.NumUnits)

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -849,28 +849,6 @@ func TestValidateComputeBatchSize(t *testing.T) {
 		WithLogger(testLogger{t: t}),
 	)
 	assert.Error(t, err)
-
-	// Set invalid value of 4 (batch sizes must be divisible by 8)
-	opts.ComputeBatchSize = 4
-	_, err = NewInitializer(
-		WithNodeId(nodeId),
-		WithCommitmentAtxId(commitmentAtxId),
-		WithConfig(cfg),
-		WithInitOpts(opts),
-		WithLogger(testLogger{t: t}),
-	)
-	assert.Error(t, err)
-
-	// Set invalid value of 13 (batch sizes must be divisible by 8)
-	opts.ComputeBatchSize = 13
-	_, err = NewInitializer(
-		WithNodeId(nodeId),
-		WithCommitmentAtxId(commitmentAtxId),
-		WithConfig(cfg),
-		WithInitOpts(opts),
-		WithLogger(testLogger{t: t}),
-	)
-	assert.Error(t, err)
 }
 
 func assertNumLabelsWritten(ctx context.Context, t *testing.T, init *Initializer) func() error {

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -834,6 +834,45 @@ func TestStop(t *testing.T) {
 	}
 }
 
+func TestValidateComputeBatchSize(t *testing.T) {
+	cfg := config.DefaultConfig()
+	opts := config.DefaultInitOpts()
+
+	// Set invalid value of 0
+	opts.ComputeBatchSize = 0
+
+	_, err := NewInitializer(
+		WithNodeId(nodeId),
+		WithCommitmentAtxId(commitmentAtxId),
+		WithConfig(cfg),
+		WithInitOpts(opts),
+		WithLogger(testLogger{t: t}),
+	)
+	assert.Error(t, err)
+
+	// Set invalid value of 4 (batch sizes must be divisible by 8)
+	opts.ComputeBatchSize = 4
+	_, err = NewInitializer(
+		WithNodeId(nodeId),
+		WithCommitmentAtxId(commitmentAtxId),
+		WithConfig(cfg),
+		WithInitOpts(opts),
+		WithLogger(testLogger{t: t}),
+	)
+	assert.Error(t, err)
+
+	// Set invalid value of 13 (batch sizes must be divisible by 8)
+	opts.ComputeBatchSize = 13
+	_, err = NewInitializer(
+		WithNodeId(nodeId),
+		WithCommitmentAtxId(commitmentAtxId),
+		WithConfig(cfg),
+		WithInitOpts(opts),
+		WithLogger(testLogger{t: t}),
+	)
+	assert.Error(t, err)
+}
+
 func assertNumLabelsWritten(ctx context.Context, t *testing.T, init *Initializer) func() error {
 	return func() error {
 		timer := time.NewTimer(50 * time.Millisecond)


### PR DESCRIPTION
Previously compute batch size was not being validated this could lead to crashes if an invalid value was used.

See - https://github.com/spacemeshos/go-spacemesh/issues/4287