### PR TITLE
Bump postrs v0.1.14

### DIFF
--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.1.13
+POSTRS_SETUP_REV = 0.1.14
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/internal/postrs/log.go
+++ b/internal/postrs/log.go
@@ -21,7 +21,7 @@ var (
 	oncer sync.Once
 
 	levelMap = map[zapcore.Level]C.Level{
-		zapcore.DebugLevel:  C.Debug,
+		zapcore.DebugLevel:  C.Trace,
 		zapcore.InfoLevel:   C.Info,
 		zapcore.WarnLevel:   C.Warn,
 		zapcore.ErrorLevel:  C.Error,

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -39,12 +39,14 @@ func Test_Verify(t *testing.T) {
 	commitmentAtxId := make([]byte, 32)
 	ch := make(shared.Challenge, 32)
 
+	logger := zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))
 	cfg, opts := getTestConfig(t)
 	init, err := initialization.NewInitializer(
 		initialization.WithNodeId(nodeId),
 		initialization.WithCommitmentAtxId(commitmentAtxId),
 		initialization.WithConfig(cfg),
 		initialization.WithInitOpts(opts),
+		initialization.WithLogger(logger),
 	)
 	r.NoError(err)
 	r.NoError(init.Initialize(context.Background()))
@@ -58,7 +60,7 @@ func Test_Verify(t *testing.T) {
 	)
 	r.NoError(err)
 
-	r.NoError(Verify(proof, proofMetadata, cfg, zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))))
+	r.NoError(Verify(proof, proofMetadata, cfg, logger))
 }
 
 func Test_Verify_Detects_invalid_proof(t *testing.T) {


### PR DESCRIPTION
Also, changed log level mapping. Zap doesn't differentiate between debug and trace levels. Hence to also see trace-level logs in post-rs library I changed level mapping.