### PR TITLE
Use go version from go.mod in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  go-version: "1.19"
-
 on:
   pull_request:
   push:
@@ -19,7 +16,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: fmt, tidy, generate
         run: |
           make install
@@ -38,7 +36,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: lint
@@ -60,7 +59,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: Add OpenCL support for Linux


### PR DESCRIPTION
As with poet and go-spacemesh update CI to use go version from go.mod instead of setting it explicitly.