### PR TITLE
Integrate RandomX pow

### DIFF
--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.2.0-rc4
+POSTRS_SETUP_REV = 0.2.0-rc5
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.1.14
+POSTRS_SETUP_REV = 0.2.0-rc1
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.2.0-rc1
+POSTRS_SETUP_REV = 0.2.0-rc2
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.2.0-rc5
+POSTRS_SETUP_REV = 0.2.0
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.2.0-rc2
+POSTRS_SETUP_REV = 0.2.0-rc4
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -157,7 +157,7 @@ func main() {
 		if err != nil {
 			log.Fatalln("proof generation error", err)
 		}
-		verifier, err := verifying.NewProofVerifier(nil)
+		verifier, err := verifying.NewProofVerifier()
 		if err != nil {
 			log.Fatalln("failed to create verifier", err)
 		}

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -157,7 +157,12 @@ func main() {
 		if err != nil {
 			log.Fatalln("proof generation error", err)
 		}
-		if err := verifying.Verify(proof, proofMetadata, cfg, zapLog); err != nil {
+		verifier, err := verifying.NewProofVerifier(nil)
+		if err != nil {
+			log.Fatalln("failed to create verifier", err)
+		}
+		defer verifier.Close()
+		if err := verifier.Verify(proof, proofMetadata, cfg, zapLog); err != nil {
 			log.Fatalln("failed to verify test proof", err)
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -79,17 +79,20 @@ type Config struct {
 	K2 uint32 // K2 is the number of labels below the required difficulty required for a proof.
 	K3 uint32 // K3 is the size of the subset of proof indices that is validated.
 
-	PowDifficulty [32]byte
+	// FIXME: remove support for the old scrypt-based PoW
+	K2PowDifficulty uint64
+	PowDifficulty   [32]byte
 }
 
 func DefaultConfig() Config {
 	cfg := Config{
-		LabelsPerUnit: 512, // 8kB units
-		MaxNumUnits:   defaultMaxNumUnits,
-		MinNumUnits:   defaultMinNumUnits,
-		K1:            26,
-		K2:            37,
-		K3:            37,
+		LabelsPerUnit:   512, // 8kB units
+		MaxNumUnits:     defaultMaxNumUnits,
+		MinNumUnits:     defaultMinNumUnits,
+		K1:              26,
+		K2:              37,
+		K3:              37,
+		K2PowDifficulty: 0x0FFFFFFF_FFFFFFFF,
 	}
 	for i := range cfg.PowDifficulty {
 		cfg.PowDifficulty[i] = 0xFF
@@ -124,6 +127,14 @@ func (p *ScryptParams) Validate() error {
 		return errors.New("scrypt parameter p cannot be 0")
 	}
 	return nil
+}
+
+func DefaultPowParams() ScryptParams {
+	return ScryptParams{
+		N: 128,
+		R: 1,
+		P: 1,
+	}
 }
 
 func DefaultLabelParams() ScryptParams {

--- a/internal/postrs/api.go
+++ b/internal/postrs/api.go
@@ -32,7 +32,7 @@ type option struct {
 	providerID *uint
 
 	commitment    []byte
-	n             uint32
+	n             uint
 	vrfDifficulty []byte
 
 	logger *zap.Logger
@@ -79,7 +79,7 @@ func WithCommitment(commitment []byte) OptionFunc {
 }
 
 // WithScryptN sets the N parameter for the scrypt computation.
-func WithScryptN(n uint32) OptionFunc {
+func WithScryptN(n uint) OptionFunc {
 	return func(opts *option) error {
 		opts.n = n
 		return nil

--- a/internal/postrs/proof.go
+++ b/internal/postrs/proof.go
@@ -10,13 +10,15 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"unsafe"
 
 	"go.uber.org/zap"
 
-	"github.com/spacemeshos/post/config"
 	"github.com/spacemeshos/post/shared"
 )
+
+type ScryptParams = C.ScryptParams
 
 // Translate scrypt parameters expressed as N,R,P to Nfactor, Rfactor and Pfactor
 // that are understood by scrypt-jane.
@@ -24,15 +26,15 @@ import (
 // N = 1 << (nfactor + 1)
 // r = 1 << rfactor
 // p = 1 << pfactor
-func translateScryptParams(params config.ScryptParams) C.ScryptParams {
-	return C.ScryptParams{
-		nfactor: C.uint8_t(math.Log2(float64(params.N))) - 1,
-		rfactor: C.uint8_t(math.Log2(float64(params.R))),
-		pfactor: C.uint8_t(math.Log2(float64(params.P))),
+func TranslateScryptParams(n, r, p uint) ScryptParams {
+	return ScryptParams{
+		nfactor: C.uint8_t(math.Log2(float64(n))) - 1,
+		rfactor: C.uint8_t(math.Log2(float64(r))),
+		pfactor: C.uint8_t(math.Log2(float64(p))),
 	}
 }
 
-func GenerateProof(dataDir string, challenge []byte, cfg config.Config, logger *zap.Logger, nonces uint, threads uint, powScrypt config.ScryptParams) (*shared.Proof, error) {
+func GenerateProof(dataDir string, challenge []byte, logger *zap.Logger, nonces uint, threads uint, K1, K2 uint32, powDifficulty [32]byte, powFlags PowFlags) (*shared.Proof, error) {
 	if logger != nil {
 		setLogCallback(logger)
 	}
@@ -44,10 +46,11 @@ func GenerateProof(dataDir string, challenge []byte, cfg config.Config, logger *
 	defer C.free(challengePtr)
 
 	config := C.Config{
-		k1:                C.uint32_t(cfg.K1),
-		k2:                C.uint32_t(cfg.K2),
-		k2_pow_difficulty: C.uint64_t(cfg.K2PowDifficulty),
-		pow_scrypt:        translateScryptParams(powScrypt),
+		k1: C.uint32_t(K1),
+		k2: C.uint32_t(K2),
+	}
+	for i, b := range powDifficulty {
+		config.pow_difficulty[i] = C.uchar(b)
 	}
 
 	cProof := C.generate_proof(
@@ -56,6 +59,7 @@ func GenerateProof(dataDir string, challenge []byte, cfg config.Config, logger *
 		config,
 		C.size_t(nonces),
 		C.size_t(threads),
+		powFlags,
 	)
 
 	if cProof == nil {
@@ -69,11 +73,65 @@ func GenerateProof(dataDir string, challenge []byte, cfg config.Config, logger *
 	return &shared.Proof{
 		Nonce:   uint32(cProof.nonce),
 		Indices: indices,
-		K2Pow:   uint64(cProof.k2_pow),
+		Pow:     uint64(cProof.pow),
 	}, nil
 }
 
-func VerifyProof(proof *shared.Proof, metadata *shared.ProofMetadata, cfg config.Config, logger *zap.Logger, powScrypt, labelScrypt config.ScryptParams) error {
+type PowFlags = C.RandomXFlag
+
+// Get the recommended PoW flags.
+//
+// Does not include:
+// * FLAG_LARGE_PAGES
+// * FLAG_FULL_MEM
+// * FLAG_SECURE
+//
+// The above flags need to be set manually, if required.
+func GetRecommendedPowFlags() PowFlags {
+	return C.recommended_pow_flags()
+}
+
+const (
+	// Use the full dataset. AKA "Fast mode".
+	PowFastMode = C.RandomXFlag_FLAG_FULL_MEM
+	// Allocate memory in large pages.
+	PowLargePages = C.RandomXFlag_FLAG_LARGE_PAGES
+	// Use JIT compilation support.
+	PowJIT = C.RandomXFlag_FLAG_JIT
+	// When combined with FLAG_JIT, the JIT pages are never writable and executable at the same time.
+	PowSecure = C.RandomXFlag_FLAG_SECURE
+	// Use hardware accelerated AES.
+	PowHardAES = C.RandomXFlag_FLAG_HARD_AES
+	// Optimize Argon2 for CPUs with the SSSE3 instruction set.
+	PowArgon2SSSE3 = C.RandomXFlag_FLAG_ARGON2_SSSE3
+	// Optimize Argon2 for CPUs with the SSSE3 instruction set.
+	PowArgon2AVX2 = C.RandomXFlag_FLAG_ARGON2_AVX2
+	// Optimize Argon2 for CPUs without the AVX2 or SSSE3 instruction sets.
+	PowArgon2 = C.RandomXFlag_FLAG_ARGON2
+)
+
+type Verifier struct {
+	inner     *C.Verifier
+	closeOnce sync.Once
+}
+
+// Create a new verifier.
+// The verifier must be closed after use with Close().
+func NewVerifier(powFlags PowFlags) (*Verifier, error) {
+	verifier := Verifier{}
+	result := C.new_verifier(powFlags, &verifier.inner)
+	if result != C.Ok {
+		return nil, fmt.Errorf("failed to create verifier")
+	}
+	return &verifier, nil
+}
+
+func (v *Verifier) Close() error {
+	v.closeOnce.Do(func() { C.free_verifier(v.inner) })
+	return nil
+}
+
+func (v *Verifier) VerifyProof(proof *shared.Proof, metadata *shared.ProofMetadata, logger *zap.Logger, k1, k2, k3 uint32, powDifficulty [32]byte, scryptParams ScryptParams) error {
 	if logger != nil {
 		setLogCallback(logger)
 	}
@@ -98,18 +156,19 @@ func VerifyProof(proof *shared.Proof, metadata *shared.ProofMetadata, cfg config
 	}
 
 	config := C.Config{
-		k1:                C.uint32_t(cfg.K1),
-		k2:                C.uint32_t(cfg.K2),
-		k3:                C.uint32_t(cfg.K3),
-		k2_pow_difficulty: C.uint64_t(cfg.K2PowDifficulty),
-		pow_scrypt:        translateScryptParams(powScrypt),
-		scrypt:            translateScryptParams(labelScrypt),
+		k1:     C.uint32_t(k1),
+		k2:     C.uint32_t(k2),
+		k3:     C.uint32_t(k3),
+		scrypt: scryptParams,
+	}
+	for i, b := range powDifficulty {
+		config.pow_difficulty[i] = C.uchar(b)
 	}
 
 	indicesSliceHdr := (*reflect.SliceHeader)(unsafe.Pointer(&proof.Indices))
 	cProof := C.Proof{
-		nonce:  C.uint32_t(proof.Nonce),
-		k2_pow: C.uint64_t(proof.K2Pow),
+		nonce: C.uint32_t(proof.Nonce),
+		pow:   C.uint64_t(proof.Pow),
 		indices: C.ArrayU8{
 			ptr: (*C.uchar)(unsafe.Pointer(indicesSliceHdr.Data)),
 			len: C.size_t(indicesSliceHdr.Len),
@@ -125,6 +184,7 @@ func VerifyProof(proof *shared.Proof, metadata *shared.ProofMetadata, cfg config
 		labels_per_unit:   C.uint64_t(metadata.LabelsPerUnit),
 	}
 	result := C.verify_proof(
+		v.inner,
 		cProof,
 		&cMetadata,
 		config,

--- a/internal/postrs/proof.go
+++ b/internal/postrs/proof.go
@@ -131,7 +131,20 @@ func (v *Verifier) Close() error {
 	return nil
 }
 
-func (v *Verifier) VerifyProof(proof *shared.Proof, metadata *shared.ProofMetadata, logger *zap.Logger, k1, k2, k3 uint32, powDifficulty [32]byte, scryptParams ScryptParams) error {
+type ScryptPowParams struct {
+	Scrypt     ScryptParams
+	Difficulty uint64
+}
+
+func (v *Verifier) VerifyProof(
+	proof *shared.Proof,
+	metadata *shared.ProofMetadata,
+	logger *zap.Logger,
+	k1, k2, k3 uint32,
+	scryptPow ScryptPowParams,
+	powDifficulty [32]byte,
+	scryptParams ScryptParams,
+) error {
 	if logger != nil {
 		setLogCallback(logger)
 	}
@@ -160,6 +173,9 @@ func (v *Verifier) VerifyProof(proof *shared.Proof, metadata *shared.ProofMetada
 		k2:     C.uint32_t(k2),
 		k3:     C.uint32_t(k3),
 		scrypt: scryptParams,
+		// FIXME: remove support for old the scrypt-based PoW
+		k2_pow_difficulty: C.uint64_t(scryptPow.Difficulty),
+		pow_scrypt:        scryptPow.Scrypt,
 	}
 	for i, b := range powDifficulty {
 		config.pow_difficulty[i] = C.uchar(b)

--- a/internal/postrs/proof_test.go
+++ b/internal/postrs/proof_test.go
@@ -4,18 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/spacemeshos/post/config"
 )
 
 func TestTranslateScryptParams(t *testing.T) {
-	params := config.ScryptParams{
-		N: 1 << (15 + 1),
-		R: 1 << 5,
-		P: 1 << 1,
-	}
+	n := uint(1 << (15 + 1))
+	r := uint(1 << 5)
+	p := uint(1 << 1)
 
-	cParams := translateScryptParams(params)
+	cParams := TranslateScryptParams(n, r, p)
 
 	require.EqualValues(t, 15, cParams.nfactor)
 	require.EqualValues(t, 5, cParams.rfactor)

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -17,7 +17,7 @@ type option struct {
 	providerID *uint
 
 	commitment    []byte
-	n             uint32
+	n             uint
 	vrfDifficulty []byte
 
 	logger *zap.Logger

--- a/proving/proving.go
+++ b/proving/proving.go
@@ -18,7 +18,7 @@ func Generate(ctx context.Context, ch shared.Challenge, cfg config.Config, logge
 	options := option{
 		threads:  1,
 		nonces:   16,
-		powFlags: postrs.GetRecommendedPowFlags() | postrs.PowFastMode,
+		powFlags: config.DefaultProvingPowFlags(),
 	}
 	for _, opt := range opts {
 		if err := opt(&options); err != nil {

--- a/proving/proving_options.go
+++ b/proving/proving_options.go
@@ -13,7 +13,7 @@ type option struct {
 	nodeId          []byte
 	commitmentAtxId []byte
 	numUnits        uint32
-	powScrypt       config.ScryptParams
+	powFlags        config.PowFlags
 	// How many nonces to try in parallel.
 	nonces uint
 	// How many threads to use to generate a proof.
@@ -28,9 +28,7 @@ func (o *option) validate() error {
 	if o.nonces == 0 {
 		return errors.New("`nonces` must be greater than 0")
 	}
-	if err := o.powScrypt.Validate(); err != nil {
-		return err
-	}
+
 	return nil
 }
 
@@ -62,9 +60,9 @@ func WithDataSource(cfg config.Config, nodeId, commitmentAtxId []byte, datadir s
 	}
 }
 
-func WithPowScryptParams(params config.ScryptParams) OptionFunc {
+func WithPowFlags(flags config.PowFlags) OptionFunc {
 	return func(o *option) error {
-		o.powScrypt = params
+		o.powFlags = flags
 		return nil
 	}
 }

--- a/proving/proving_test.go
+++ b/proving/proving_test.go
@@ -87,7 +87,7 @@ func Test_Generate(t *testing.T) {
 				zap.Uint64("numLabels", numLabels),
 				zap.Int("indices size", len(proof.Indices)),
 			)
-			verifier, err := verifying.NewProofVerifier(nil)
+			verifier, err := verifying.NewProofVerifier()
 			r.NoError(err)
 			defer verifier.Close()
 			r.NoError(verifier.Verify(
@@ -232,7 +232,7 @@ func Test_Generate_TestNetSettings(t *testing.T) {
 		zap.Uint64("numLabels", numLabels),
 		zap.Int("indices size", len(proof.Indices)),
 	)
-	verifier, err := verifying.NewProofVerifier(nil)
+	verifier, err := verifying.NewProofVerifier()
 	r.NoError(err)
 	defer verifier.Close()
 	r.NoError(verifier.Verify(

--- a/proving/proving_test.go
+++ b/proving/proving_test.go
@@ -67,6 +67,7 @@ func Test_Generate(t *testing.T) {
 				log,
 				WithDataSource(cfg, nodeId, commitmentAtxId, opts.DataDir),
 				WithThreads(2),
+				WithPowFlags(postrs.GetRecommendedPowFlags()),
 			)
 			r.NoError(err, "numUnits: %d", opts.NumUnits)
 			r.NotNil(proof)
@@ -86,7 +87,10 @@ func Test_Generate(t *testing.T) {
 				zap.Uint64("numLabels", numLabels),
 				zap.Int("indices size", len(proof.Indices)),
 			)
-			r.NoError(verifying.Verify(
+			verifier, err := verifying.NewProofVerifier(nil)
+			r.NoError(err)
+			defer verifier.Close()
+			r.NoError(verifier.Verify(
 				proof,
 				proofMetaData,
 				cfg,
@@ -118,7 +122,14 @@ func Test_Generate_DetectInvalidParameters(t *testing.T) {
 		copy(newNodeId, nodeId)
 		newNodeId[0] = newNodeId[0] + 1
 
-		_, _, err := Generate(context.Background(), ch, cfg, zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel)), WithDataSource(cfg, newNodeId, commitmentAtxId, opts.DataDir))
+		_, _, err := Generate(
+			context.Background(),
+			ch,
+			cfg,
+			zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel)),
+			WithDataSource(cfg, newNodeId, commitmentAtxId, opts.DataDir),
+			WithPowFlags(postrs.GetRecommendedPowFlags()),
+		)
 		var errConfigMismatch initialization.ConfigMismatchError
 		require.ErrorAs(t, err, &errConfigMismatch)
 		require.Equal(t, "NodeId", errConfigMismatch.Param)
@@ -129,7 +140,14 @@ func Test_Generate_DetectInvalidParameters(t *testing.T) {
 		copy(newAtxId, commitmentAtxId)
 		newAtxId[0] = newAtxId[0] + 1
 
-		_, _, err := Generate(context.Background(), ch, cfg, zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel)), WithDataSource(cfg, nodeId, newAtxId, opts.DataDir))
+		_, _, err := Generate(
+			context.Background(),
+			ch,
+			cfg,
+			zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel)),
+			WithDataSource(cfg, nodeId, newAtxId, opts.DataDir),
+			WithPowFlags(postrs.GetRecommendedPowFlags()),
+		)
 		var errConfigMismatch initialization.ConfigMismatchError
 		require.ErrorAs(t, err, &errConfigMismatch)
 		require.Equal(t, "CommitmentAtxId", errConfigMismatch.Param)
@@ -139,7 +157,14 @@ func Test_Generate_DetectInvalidParameters(t *testing.T) {
 		newCfg := cfg
 		newCfg.LabelsPerUnit++
 
-		_, _, err := Generate(context.Background(), ch, newCfg, zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel)), WithDataSource(newCfg, nodeId, commitmentAtxId, opts.DataDir))
+		_, _, err := Generate(
+			context.Background(),
+			ch,
+			newCfg,
+			zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel)),
+			WithDataSource(newCfg, nodeId, commitmentAtxId, opts.DataDir),
+			WithPowFlags(postrs.GetRecommendedPowFlags()),
+		)
 		var errConfigMismatch initialization.ConfigMismatchError
 		require.ErrorAs(t, err, &errConfigMismatch)
 		require.Equal(t, "LabelsPerUnit", errConfigMismatch.Param)
@@ -181,7 +206,14 @@ func Test_Generate_TestNetSettings(t *testing.T) {
 	r.NoError(err)
 	r.Equal(len(ch), n)
 
-	proof, proofMetaData, err := Generate(context.Background(), ch, cfg, log, WithDataSource(cfg, nodeId, commitmentAtxId, opts.DataDir))
+	proof, proofMetaData, err := Generate(
+		context.Background(),
+		ch,
+		cfg,
+		log,
+		WithDataSource(cfg, nodeId, commitmentAtxId, opts.DataDir),
+		WithPowFlags(postrs.GetRecommendedPowFlags()),
+	)
 	r.NoError(err, "numUnits: %d", opts.NumUnits)
 	r.NotNil(proof)
 	r.NotNil(proofMetaData)
@@ -200,7 +232,10 @@ func Test_Generate_TestNetSettings(t *testing.T) {
 		zap.Uint64("numLabels", numLabels),
 		zap.Int("indices size", len(proof.Indices)),
 	)
-	r.NoError(verifying.Verify(
+	verifier, err := verifying.NewProofVerifier(nil)
+	r.NoError(err)
+	defer verifier.Close()
+	r.NoError(verifier.Verify(
 		proof,
 		proofMetaData,
 		cfg,

--- a/shared/proof.go
+++ b/shared/proof.go
@@ -3,7 +3,7 @@ package shared
 type Proof struct {
 	Nonce   uint32
 	Indices []byte
-	K2Pow   uint64
+	Pow     uint64
 }
 
 type ProofMetadata struct {

--- a/verifying/verifying.go
+++ b/verifying/verifying.go
@@ -102,5 +102,8 @@ func (v *ProofVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, cfg con
 	}
 
 	scryptParams := postrs.TranslateScryptParams(options.labelScrypt.N, options.labelScrypt.R, options.labelScrypt.P)
-	return v.inner.VerifyProof(p, m, logger, cfg.K1, cfg.K2, cfg.K3, cfg.PowDifficulty, scryptParams)
+	return v.inner.VerifyProof(p, m, logger, cfg.K1, cfg.K2, cfg.K3, postrs.ScryptPowParams{
+		Difficulty: cfg.K2PowDifficulty,
+		Scrypt:     postrs.TranslateScryptParams(options.powScrypt.N, options.powScrypt.R, options.powScrypt.P),
+	}, cfg.PowDifficulty, scryptParams)
 }

--- a/verifying/verifying.go
+++ b/verifying/verifying.go
@@ -60,39 +60,30 @@ func VerifyVRFNonce(nonce *uint64, m *shared.VRFNonceMetadata, opts ...OptionFun
 }
 
 type ProofVerifier struct {
-	inner *postrs.Verifier
+	*postrs.Verifier
 }
 
 // NewProofVerifier creates a new proof verifier.
-// If powFlags is nil, the recommended PoW flags will be used.
 // The verifier must be closed after use with Close().
-func NewProofVerifier(powFlags *config.PowFlags) (*ProofVerifier, error) {
-	var flags config.PowFlags
-	if powFlags == nil {
-		flags = config.DefaultVerifyingPowFlags()
-	} else {
-		flags = *powFlags
+func NewProofVerifier(opts ...OptionFunc) (*ProofVerifier, error) {
+	options, err := applyOpts(opts...)
+	if err != nil {
+		return nil, err
 	}
-	inner, err := postrs.NewVerifier(flags)
+	inner, err := postrs.NewVerifier(options.powFlags)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ProofVerifier{inner: inner}, nil
-}
-
-func (v *ProofVerifier) Close() error {
-	return v.inner.Close()
+	return &ProofVerifier{inner}, nil
 }
 
 // Verify ensures the validity of a proof in respect to its metadata.
 // It returns nil if the proof is valid or an error describing the failure, otherwise.
 func (v *ProofVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, cfg config.Config, logger *zap.Logger, opts ...OptionFunc) error {
-	options := defaultOpts()
-	for _, opt := range opts {
-		if err := opt(options); err != nil {
-			return err
-		}
+	options, err := applyOpts(opts...)
+	if err != nil {
+		return err
 	}
 	if len(m.NodeId) != 32 {
 		return fmt.Errorf("invalid `nodeId` length; expected: 32, given: %v", len(m.NodeId))
@@ -102,7 +93,7 @@ func (v *ProofVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, cfg con
 	}
 
 	scryptParams := postrs.TranslateScryptParams(options.labelScrypt.N, options.labelScrypt.R, options.labelScrypt.P)
-	return v.inner.VerifyProof(p, m, logger, cfg.K1, cfg.K2, cfg.K3, postrs.ScryptPowParams{
+	return v.VerifyProof(p, m, logger, cfg.K1, cfg.K2, cfg.K3, postrs.ScryptPowParams{
 		Difficulty: cfg.K2PowDifficulty,
 		Scrypt:     postrs.TranslateScryptParams(options.powScrypt.N, options.powScrypt.R, options.powScrypt.P),
 	}, cfg.PowDifficulty, scryptParams)

--- a/verifying/verifying_options.go
+++ b/verifying/verifying_options.go
@@ -5,15 +5,12 @@ import (
 )
 
 type option struct {
-	// scrypt parameters for AES PoW
-	powScrypt config.ScryptParams
 	// scrypt parameters for labels initialization
 	labelScrypt config.ScryptParams
 }
 
 func defaultOpts() *option {
 	return &option{
-		powScrypt:   config.DefaultPowParams(),
 		labelScrypt: config.DefaultLabelParams(),
 	}
 }
@@ -23,13 +20,6 @@ type OptionFunc func(*option) error
 func WithLabelScryptParams(params config.ScryptParams) OptionFunc {
 	return func(o *option) error {
 		o.labelScrypt = params
-		return nil
-	}
-}
-
-func WithPowScryptParams(params config.ScryptParams) OptionFunc {
-	return func(o *option) error {
-		o.powScrypt = params
 		return nil
 	}
 }

--- a/verifying/verifying_options.go
+++ b/verifying/verifying_options.go
@@ -5,6 +5,7 @@ import (
 )
 
 type option struct {
+	powFlags config.PowFlags
 	// scrypt parameters for AES PoW
 	powScrypt config.ScryptParams
 	// scrypt parameters for labels initialization
@@ -13,9 +14,20 @@ type option struct {
 
 func defaultOpts() *option {
 	return &option{
+		powFlags:    config.DefaultVerifyingPowFlags(),
 		powScrypt:   config.DefaultPowParams(),
 		labelScrypt: config.DefaultLabelParams(),
 	}
+}
+
+func applyOpts(options ...OptionFunc) (*option, error) {
+	opts := defaultOpts()
+	for _, opt := range options {
+		if err := opt(opts); err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
 }
 
 type OptionFunc func(*option) error
@@ -30,6 +42,13 @@ func WithLabelScryptParams(params config.ScryptParams) OptionFunc {
 func WithPowScryptParams(params config.ScryptParams) OptionFunc {
 	return func(o *option) error {
 		o.powScrypt = params
+		return nil
+	}
+}
+
+func WithPowFlags(flags config.PowFlags) OptionFunc {
+	return func(o *option) error {
+		o.powFlags = flags
 		return nil
 	}
 }

--- a/verifying/verifying_options.go
+++ b/verifying/verifying_options.go
@@ -5,12 +5,15 @@ import (
 )
 
 type option struct {
+	// scrypt parameters for AES PoW
+	powScrypt config.ScryptParams
 	// scrypt parameters for labels initialization
 	labelScrypt config.ScryptParams
 }
 
 func defaultOpts() *option {
 	return &option{
+		powScrypt:   config.DefaultPowParams(),
 		labelScrypt: config.DefaultLabelParams(),
 	}
 }
@@ -20,6 +23,13 @@ type OptionFunc func(*option) error
 func WithLabelScryptParams(params config.ScryptParams) OptionFunc {
 	return func(o *option) error {
 		o.labelScrypt = params
+		return nil
+	}
+}
+
+func WithPowScryptParams(params config.ScryptParams) OptionFunc {
+	return func(o *option) error {
+		o.powScrypt = params
 		return nil
 	}
 }

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -65,7 +65,7 @@ func Test_Verify(t *testing.T) {
 	)
 	r.NoError(err)
 
-	verifier, err := NewProofVerifier(nil)
+	verifier, err := NewProofVerifier()
 	r.NoError(err)
 	defer verifier.Close()
 
@@ -101,7 +101,7 @@ func Test_Verify_Detects_invalid_proof(t *testing.T) {
 	for i := range proof.Indices {
 		proof.Indices[i] ^= 255 // flip bits in all indices
 	}
-	verifier, err := NewProofVerifier(nil)
+	verifier, err := NewProofVerifier()
 	r.NoError(err)
 	defer verifier.Close()
 
@@ -154,7 +154,7 @@ func BenchmarkVerifying(b *testing.B) {
 	p, m, err := proving.Generate(context.Background(), ch, cfg, zaptest.NewLogger(b), proving.WithDataSource(cfg, nodeId, commitmentAtxId, opts.DataDir))
 	require.NoError(b, err)
 
-	verifier, err := NewProofVerifier(nil)
+	verifier, err := NewProofVerifier()
 	require.NoError(b, err)
 	defer verifier.Close()
 
@@ -199,7 +199,7 @@ func Benchmark_Verify_Fastnet(b *testing.B) {
 	r.NoError(err)
 	r.NoError(init.Initialize(context.Background()))
 
-	verifier, err := NewProofVerifier(nil)
+	verifier, err := NewProofVerifier()
 	require.NoError(b, err)
 	defer verifier.Close()
 

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -21,6 +21,10 @@ import (
 func getTestConfig(tb testing.TB) (config.Config, config.InitOpts) {
 	cfg := config.DefaultConfig()
 
+	cfg.K1 = 3
+	cfg.K2 = 3
+	cfg.K3 = 3
+
 	id := postrs.CPUProviderID()
 	require.NotZero(tb, id)
 
@@ -57,10 +61,15 @@ func Test_Verify(t *testing.T) {
 		cfg,
 		zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel)),
 		proving.WithDataSource(cfg, nodeId, commitmentAtxId, opts.DataDir),
+		proving.WithPowFlags(postrs.GetRecommendedPowFlags()),
 	)
 	r.NoError(err)
 
-	r.NoError(Verify(proof, proofMetadata, cfg, logger))
+	verifier, err := NewProofVerifier(nil)
+	r.NoError(err)
+	defer verifier.Close()
+
+	r.NoError(verifier.Verify(proof, proofMetadata, cfg, logger))
 }
 
 func Test_Verify_Detects_invalid_proof(t *testing.T) {
@@ -92,8 +101,11 @@ func Test_Verify_Detects_invalid_proof(t *testing.T) {
 	for i := range proof.Indices {
 		proof.Indices[i] ^= 255 // flip bits in all indices
 	}
+	verifier, err := NewProofVerifier(nil)
+	r.NoError(err)
+	defer verifier.Close()
 
-	r.ErrorContains(Verify(proof, proofMetadata, cfg, zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))), "invalid proof")
+	r.ErrorContains(verifier.Verify(proof, proofMetadata, cfg, zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))), "invalid proof")
 }
 
 func TestVerifyPow(t *testing.T) {
@@ -142,6 +154,10 @@ func BenchmarkVerifying(b *testing.B) {
 	p, m, err := proving.Generate(context.Background(), ch, cfg, zaptest.NewLogger(b), proving.WithDataSource(cfg, nodeId, commitmentAtxId, opts.DataDir))
 	require.NoError(b, err)
 
+	verifier, err := NewProofVerifier(nil)
+	require.NoError(b, err)
+	defer verifier.Close()
+
 	for _, k3 := range []uint32{5, 25, 50, 100} {
 		testName := fmt.Sprintf("k3=%d", k3)
 
@@ -150,7 +166,7 @@ func BenchmarkVerifying(b *testing.B) {
 		b.Run(testName, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				start := time.Now()
-				err := Verify(p, m, cfg, zaptest.NewLogger(b))
+				err := verifier.Verify(p, m, cfg, zaptest.NewLogger(b))
 				require.NoError(b, err)
 				b.ReportMetric(time.Since(start).Seconds(), "sec/proof")
 			}
@@ -183,6 +199,10 @@ func Benchmark_Verify_Fastnet(b *testing.B) {
 	r.NoError(err)
 	r.NoError(init.Initialize(context.Background()))
 
+	verifier, err := NewProofVerifier(nil)
+	require.NoError(b, err)
+	defer verifier.Close()
+
 	for i := 0; i < b.N; i++ {
 		rand.Read(ch)
 		proof, proofMetadata, err := proving.Generate(context.Background(), ch, cfg, zaptest.NewLogger(b), proving.WithDataSource(cfg, nodeId, commitmentAtxId, opts.DataDir))
@@ -190,7 +210,7 @@ func Benchmark_Verify_Fastnet(b *testing.B) {
 
 		b.StartTimer()
 		start := time.Now()
-		r.NoError(Verify(proof, proofMetadata, cfg, zaptest.NewLogger(b)))
+		r.NoError(verifier.Verify(proof, proofMetadata, cfg, zaptest.NewLogger(b)))
 		b.ReportMetric(time.Since(start).Seconds(), "sec/proof")
 		b.StopTimer()
 	}


### PR DESCRIPTION
Integration of [RandomX](https://github.com/tevador/RandomX)-based proof of work in place of the scrypt-based one.

### Changes
- PoW difficulty is now 256bit, configured in form of `[32]byte` array;
- verifier is now stateful because RandomX cache takes about 250ms to initialize, which is too long to do it per ATX;
- proving and verifying options take `PowFlags` that configure the operation of RandomX. They have sane defaults:
  - proving runs in FAST mode (2GiB RAM)
  - verification runs in LIGHT mode (256MiB RAM)
- renamed "K2 PoW" to just "PoW" everywhere. Reasoning - there is only one PoW in POST now AND the old name was uninformative anyway.

:bulb: configuration of RandomX flags affect speed and memory requirements only - misconfiguring it won't affect the generated pow nonce correctness.

:bulb: `postrs.Verifier` can be used from many threads safely.