### PR TITLE
Bump post-rs to v0.2.1

### DIFF
--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,16 +49,16 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.2.0
+POSTRS_SETUP_REV = 0.2.1
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)
-	POSTRS_SETUP_LIBS = prover.h post.dll
+	POSTRS_SETUP_LIBS = post.h post.dll
 else
 	ifeq ($(platform), $(filter $(platform), macos macos-m1))
-		POSTRS_SETUP_LIBS = prover.h libpost.dylib
+		POSTRS_SETUP_LIBS = post.h libpost.dylib
 	else
-		POSTRS_SETUP_LIBS = prover.h libpost.so
+		POSTRS_SETUP_LIBS = post.h libpost.so
 	endif
 endif
 

--- a/internal/postrs/api.go
+++ b/internal/postrs/api.go
@@ -1,7 +1,7 @@
 package postrs
 
 // #cgo LDFLAGS: -lpost
-// #include "prover.h"
+// #include "post.h"
 import "C"
 
 import (

--- a/internal/postrs/initializer.go
+++ b/internal/postrs/initializer.go
@@ -2,7 +2,7 @@ package postrs
 
 // #cgo LDFLAGS: -lpost
 // #include <stdlib.h>
-// #include "prover.h"
+// #include "post.h"
 import "C"
 
 import (

--- a/internal/postrs/log.go
+++ b/internal/postrs/log.go
@@ -2,7 +2,7 @@ package postrs
 
 // #cgo LDFLAGS: -lpost
 // #include <stdlib.h>
-// #include "prover.h"
+// #include "post.h"
 //
 // // forward declarations for callback C functions
 // void logCallback(ExternCRecord* record);

--- a/internal/postrs/proof.go
+++ b/internal/postrs/proof.go
@@ -2,7 +2,7 @@ package postrs
 
 // #cgo LDFLAGS: -lpost
 // #include <stdlib.h>
-// #include "prover.h"
+// #include "post.h"
 import "C"
 
 import (


### PR DESCRIPTION
- fixed scrypt-base pow verification,
- renamed prover.h to post.h to match the library name,