### PR TITLE
Bump post-rs to v0.3.0

### DIFF
--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.2.1
+POSTRS_SETUP_REV = 0.3.0
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/config/config.go
+++ b/config/config.go
@@ -79,20 +79,17 @@ type Config struct {
 	K2 uint32 // K2 is the number of labels below the required difficulty required for a proof.
 	K3 uint32 // K3 is the size of the subset of proof indices that is validated.
 
-	// FIXME: remove support for the old scrypt-based PoW
-	K2PowDifficulty uint64
-	PowDifficulty   [32]byte
+	PowDifficulty [32]byte
 }
 
 func DefaultConfig() Config {
 	cfg := Config{
-		LabelsPerUnit:   512, // 8kB units
-		MaxNumUnits:     defaultMaxNumUnits,
-		MinNumUnits:     defaultMinNumUnits,
-		K1:              26,
-		K2:              37,
-		K3:              37,
-		K2PowDifficulty: 0x0FFFFFFF_FFFFFFFF,
+		LabelsPerUnit: 512, // 8kB units
+		MaxNumUnits:   defaultMaxNumUnits,
+		MinNumUnits:   defaultMinNumUnits,
+		K1:            26,
+		K2:            37,
+		K3:            37,
 	}
 	for i := range cfg.PowDifficulty {
 		cfg.PowDifficulty[i] = 0xFF
@@ -127,14 +124,6 @@ func (p *ScryptParams) Validate() error {
 		return errors.New("scrypt parameter p cannot be 0")
 	}
 	return nil
-}
-
-func DefaultPowParams() ScryptParams {
-	return ScryptParams{
-		N: 128,
-		R: 1,
-		P: 1,
-	}
 }
 
 func DefaultLabelParams() ScryptParams {

--- a/internal/postrs/proof.go
+++ b/internal/postrs/proof.go
@@ -131,17 +131,11 @@ func (v *Verifier) Close() error {
 	return nil
 }
 
-type ScryptPowParams struct {
-	Scrypt     ScryptParams
-	Difficulty uint64
-}
-
 func (v *Verifier) VerifyProof(
 	proof *shared.Proof,
 	metadata *shared.ProofMetadata,
 	logger *zap.Logger,
 	k1, k2, k3 uint32,
-	scryptPow ScryptPowParams,
 	powDifficulty [32]byte,
 	scryptParams ScryptParams,
 ) error {
@@ -173,9 +167,6 @@ func (v *Verifier) VerifyProof(
 		k2:     C.uint32_t(k2),
 		k3:     C.uint32_t(k3),
 		scrypt: scryptParams,
-		// FIXME: remove support for old the scrypt-based PoW
-		k2_pow_difficulty: C.uint64_t(scryptPow.Difficulty),
-		pow_scrypt:        scryptPow.Scrypt,
 	}
 	for i, b := range powDifficulty {
 		config.pow_difficulty[i] = C.uchar(b)

--- a/verifying/verifying.go
+++ b/verifying/verifying.go
@@ -93,8 +93,5 @@ func (v *ProofVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, cfg con
 	}
 
 	scryptParams := postrs.TranslateScryptParams(options.labelScrypt.N, options.labelScrypt.R, options.labelScrypt.P)
-	return v.VerifyProof(p, m, logger, cfg.K1, cfg.K2, cfg.K3, postrs.ScryptPowParams{
-		Difficulty: cfg.K2PowDifficulty,
-		Scrypt:     postrs.TranslateScryptParams(options.powScrypt.N, options.powScrypt.R, options.powScrypt.P),
-	}, cfg.PowDifficulty, scryptParams)
+	return v.VerifyProof(p, m, logger, cfg.K1, cfg.K2, cfg.K3, cfg.PowDifficulty, scryptParams)
 }

--- a/verifying/verifying_options.go
+++ b/verifying/verifying_options.go
@@ -6,8 +6,6 @@ import (
 
 type option struct {
 	powFlags config.PowFlags
-	// scrypt parameters for AES PoW
-	powScrypt config.ScryptParams
 	// scrypt parameters for labels initialization
 	labelScrypt config.ScryptParams
 }
@@ -15,7 +13,6 @@ type option struct {
 func defaultOpts() *option {
 	return &option{
 		powFlags:    config.DefaultVerifyingPowFlags(),
-		powScrypt:   config.DefaultPowParams(),
 		labelScrypt: config.DefaultLabelParams(),
 	}
 }
@@ -35,13 +32,6 @@ type OptionFunc func(*option) error
 func WithLabelScryptParams(params config.ScryptParams) OptionFunc {
 	return func(o *option) error {
 		o.labelScrypt = params
-		return nil
-	}
-}
-
-func WithPowScryptParams(params config.ScryptParams) OptionFunc {
-	return func(o *option) error {
-		o.powScrypt = params
 		return nil
 	}
 }


### PR DESCRIPTION
The new version contains a breaking change in the protocol - support for verifying scrypt-based K2 PoW is removed.