### PR TITLE
Run unit tests on arm64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: 
+          - ubuntu-latest
+          - [self-hosted, linux, arm64]
+          - macos-latest
+          - [self-hosted, macos, arm64]
+          - windows-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -98,14 +103,14 @@ jobs:
         include:
         - os: ubuntu-latest
           artifact-name: linux
-        - os: windows-latest
-          artifact-name: windows
-        - os: macos-latest
-          artifact-name: macos
         - os: [self-hosted, linux, arm64]
           artifact-name: linux-arm64
+        - os: macos-latest
+          artifact-name: macos
         - os: [self-hosted, macos, arm64]
           artifact-name: macos-m1
+        - os: windows-latest
+          artifact-name: windows
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,13 @@ jobs:
           go-version-file: "go.mod"
       - name: setup env
         run: make install
-      - name: Add OpenCL support for Linux
+      - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2 clinfo
-      - name: Add OpenCL support for Windows
+        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
+      - name: Override SDKROOT for macOS
+        if: ${{ contains(matrix.os, 'macos') && runner.arch == 'arm64' }}
+        run: echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk" >> $GITHUB_ENV
+      - name: Add OpenCL support - Windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: choco install opencl-intel-cpu-runtime
       - name: Clear test cache
@@ -121,11 +124,15 @@ jobs:
           go-version-file: "go.mod"
       - name: setup env
         run: make install
-      - name: Add OpenCL support for Linux
+      - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -qy ocl-icd-opencl-dev
+        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
+      - name: Override SDKROOT for macOS
+        if: ${{ contains(matrix.os, 'macos') && runner.arch == 'arm64' }}
+        run: echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk" >> $GITHUB_ENV
+      - name: Add OpenCL support - Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install opencl-intel-cpu-runtime
       - name: build postcli
         run: make build
 

--- a/proving/proving_test.go
+++ b/proving/proving_test.go
@@ -35,7 +35,6 @@ func Test_Generate(t *testing.T) {
 	for numUnits := uint32(1); numUnits < 6; numUnits++ {
 		numUnits := numUnits
 		t.Run(fmt.Sprintf("numUnits=%d", numUnits), func(t *testing.T) {
-			t.Parallel()
 			r := require.New(t)
 			log := zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))
 


### PR DESCRIPTION
Closes #161 

I had to stop parallization of initialization test because it slows down the test significantly: Ubuntu 1m40s with `t.Parallel`, 1m20s without; Linux arm64 timeout with, 1m56s without.

Initialization in parallel isn't really supported anyway. Any call to `Initialize` will wait if another goroutine is already initializing with the selected provider.