### PR TITLE
Allow initializing only subset of labels

### DIFF
--- a/cmd/postcli/README.md
+++ b/cmd/postcli/README.md
@@ -95,7 +95,7 @@ Next, on machine B:
 ```bash
 ./postcli -numUnits 100 -id <id> -commitmentAtxId <id> -fromFile 800 -datadir ./dataB
 ```
-We get the first half - 800 binary files
+We get the second half - 800 binary files
 ```bash
 ls -la ./dataB/*.bin | wc -l
 800
@@ -110,18 +110,20 @@ ls -la ./data/*.bin | wc -l
 ```
 
 **An optional step to select best possible VRF nonce**
-Normally, when `postcli`initializates from the start to the end it will automatically pick the best vrf nonce. The best means pointing to **the label with the smallest value**. It might be important in the future if we allow increasing POS data size, but it is not critical at the moment.
+Normally, when `postcli`initializates from the start to the end it will automatically pick the best VRF nonce. The best means pointing to **the label with the smallest value**. This will avoid a longer initialization time when a node increases their PoST size in the future (not supported yet).
 
-Now, when `postcli` initializes in chunks, each subset will find a valid vrf nonce, which represents the local minimum in the inititalized subset. It's optimal to select the best one (the global minimum), but it's not critical.
+Now, when `postcli` initializes in chunks, each subset will find a valid vrf nonce, which represents the local minimum in the inititalized subset. It is recommended to select the best one (the global minimum).
 
 The values of nonces are 128bit, represented as a 16B binary array in big endian. Given two nonces:
 ```
-nonceA = 0000ffda94993723a980bf557509773e
-nonceB = 0000488e171389cce69344d68b66f6b4
+NonceA = 12345
+NonceValueA = 0000ffda94993723a980bf557509773e
+NonceB = 98765
+NonceValueB = 0000488e171389cce69344d68b66f6b4
 ```
-`nonceB` represents the smaller value.
+`NonceB` is the global minimum since its value is smaller than the one of `NonceA`.
 
-The nonce and the label it points to is included in the post_metadata.json. It's currently up to the operator to find the best VRF nonce manually and copy the `Nonce` and `NonceValue` to the postdata_metadata.json on the target machine.
+The nonce (index) and noncevalue (the label) is included in the post_metadata.json. It is up to the operator to find the best VRF nonce manually and copy the `Nonce` and `NonceValue` to the postdata_metadata.json on the target machine.
 
 ### Remarks
 * `-id` and `-commitmentAtxId` are required because they are committed to the generated data.

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -50,8 +51,17 @@ func parseFlags() {
 	flag.StringVar(&idHex, "id", "", "miner's id (public key), in hex (will be auto-generated if not provided)")
 	flag.StringVar(&commitmentAtxIdHex, "commitmentAtxId", "", "commitment atx id, in hex (required)")
 	numUnits := flag.Uint64("numUnits", uint64(opts.NumUnits), "number of units")
+
+	flag.Uint64Var(&opts.From, "from", 0, "first label to initialize. Will init from 0 if not provided")
+	var to uint64
+	flag.Uint64Var(&to, "to", math.MaxUint64, "end of the range of labels to initialize (exclusive). Will init to the end of declared space if not provided.")
 	flag.Parse()
 
+	// A workaround to simulate an optional value w/o a default ¯\_(ツ)_/¯
+	// The default will be known later, after parsing the flags.
+	if to != math.MaxUint64 {
+		opts.To = &to
+	}
 	opts.NumUnits = uint32(*numUnits) // workaround the missing type support for uint32
 }
 

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -30,6 +30,7 @@ var (
 	cfg                = config.MainnetConfig()
 	opts               = config.MainnetInitOpts()
 	printProviders     bool
+	printNumFiles      bool
 	printConfig        bool
 	genProof           bool
 	idHex              string
@@ -41,6 +42,7 @@ var (
 
 func parseFlags() {
 	flag.BoolVar(&printProviders, "printProviders", false, "print the list of compute providers")
+	flag.BoolVar(&printNumFiles, "printNumFiles", false, "print the total number of files that would be initialized")
 	flag.BoolVar(&printConfig, "printConfig", false, "print the used config and options")
 	flag.BoolVar(&genProof, "genproof", false, "generate proof as a sanity test, after initialization")
 	flag.StringVar(&opts.DataDir, "datadir", opts.DataDir, "filesystem datadir path")
@@ -104,6 +106,12 @@ func main() {
 			log.Fatalln("failed to get OpenCL providers", err)
 		}
 		spew.Dump(providers)
+		return
+	}
+
+	if printNumFiles {
+		totalFiles := initialization.TotalFiles(cfg, opts)
+		fmt.Println(totalFiles)
 		return
 	}
 

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -52,15 +52,15 @@ func parseFlags() {
 	flag.StringVar(&commitmentAtxIdHex, "commitmentAtxId", "", "commitment atx id, in hex (required)")
 	numUnits := flag.Uint64("numUnits", uint64(opts.NumUnits), "number of units")
 
-	flag.Uint64Var(&opts.From, "from", 0, "first label to initialize. Will init from 0 if not provided")
-	var to uint64
-	flag.Uint64Var(&to, "to", math.MaxUint64, "end of the range of labels to initialize (exclusive). Will init to the end of declared space if not provided.")
+	flag.IntVar(&opts.FromFileIdx, "from-file", 0, "index of file to begin init from")
+	var to int
+	flag.IntVar(&to, "to-file", math.MaxInt, "index of file to init to (exclusive). Will init to the end of declared space if not provided.")
 	flag.Parse()
 
 	// A workaround to simulate an optional value w/o a default ¯\_(ツ)_/¯
 	// The default will be known later, after parsing the flags.
-	if to != math.MaxUint64 {
-		opts.To = &to
+	if to != math.MaxInt {
+		opts.ToFileIdx = &to
 	}
 	opts.NumUnits = uint32(*numUnits) // workaround the missing type support for uint32
 }

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -52,9 +52,9 @@ func parseFlags() {
 	flag.StringVar(&commitmentAtxIdHex, "commitmentAtxId", "", "commitment atx id, in hex (required)")
 	numUnits := flag.Uint64("numUnits", uint64(opts.NumUnits), "number of units")
 
-	flag.IntVar(&opts.FromFileIdx, "from-file", 0, "index of file to begin init from")
+	flag.IntVar(&opts.FromFileIdx, "fromFile", 0, "index of the first file to init (inclusive)")
 	var to int
-	flag.IntVar(&to, "to-file", math.MaxInt, "index of file to init to (exclusive). Will init to the end of declared space if not provided.")
+	flag.IntVar(&to, "toFile", math.MaxInt, "index of the last file to init (inclusive). Will init to the end of declared space if not provided.")
 	flag.Parse()
 
 	// A workaround to simulate an optional value w/o a default ¯\_(ツ)_/¯

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -110,7 +110,7 @@ func main() {
 	}
 
 	if printNumFiles {
-		totalFiles := initialization.TotalFiles(cfg, opts)
+		totalFiles := opts.TotalFiles(cfg.LabelsPerUnit)
 		fmt.Println(totalFiles)
 		return
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -117,6 +117,10 @@ func DefaultConfig() Config {
 	return cfg
 }
 
+func (c *Config) UnitSize() uint64 {
+	return c.LabelsPerUnit * uint64(BytesPerLabel())
+}
+
 type InitOpts struct {
 	DataDir     string
 	NumUnits    uint32

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,10 @@ func init() {
 	DefaultDataDir = filepath.Join(home, "post", DefaultDataDirName)
 }
 
+func BytesPerLabel() int {
+	return BitsPerLabel / 8
+}
+
 type PowFlags = postrs.PowFlags
 
 const (
@@ -123,8 +127,14 @@ type InitOpts struct {
 	// ComputeBatchSize must be greater than 0
 	ComputeBatchSize uint64
 
-	From uint64
-	To   *uint64
+	// Index of file to start from
+	FromFileIdx int
+	// Index of file to init to (exclusive). Will init to the end of declared space if not provided.
+	ToFileIdx *int
+}
+
+func (o *InitOpts) MaxFileNumLabels() uint64 {
+	return o.MaxFileSize / uint64(BytesPerLabel())
 }
 
 type ScryptParams struct {

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -139,6 +140,13 @@ type InitOpts struct {
 
 func (o *InitOpts) MaxFileNumLabels() uint64 {
 	return o.MaxFileSize / uint64(BytesPerLabel())
+}
+
+func (o *InitOpts) TotalLabels(labelsPerUnit uint64) uint64 {
+	return uint64(o.NumUnits) * labelsPerUnit
+}
+func (o *InitOpts) TotalFiles(labelsPerUnit uint64) int {
+	return int(math.Ceil(float64(o.TotalLabels(labelsPerUnit)) / float64(o.MaxFileNumLabels())))
 }
 
 type ScryptParams struct {

--- a/config/config.go
+++ b/config/config.go
@@ -145,6 +145,7 @@ func (o *InitOpts) MaxFileNumLabels() uint64 {
 func (o *InitOpts) TotalLabels(labelsPerUnit uint64) uint64 {
 	return uint64(o.NumUnits) * labelsPerUnit
 }
+
 func (o *InitOpts) TotalFiles(labelsPerUnit uint64) int {
 	return int(math.Ceil(float64(o.TotalLabels(labelsPerUnit)) / float64(o.MaxFileNumLabels())))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -127,9 +127,9 @@ type InitOpts struct {
 	// ComputeBatchSize must be greater than 0
 	ComputeBatchSize uint64
 
-	// Index of file to start from
+	// Index of the first file to init (inclusive)
 	FromFileIdx int
-	// Index of file to init to (exclusive). Will init to the end of declared space if not provided.
+	// Index of the last file to init (inclusive). Will init to the end of declared space if not provided.
 	ToFileIdx *int
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,9 @@ type InitOpts struct {
 	Scrypt      ScryptParams
 	// ComputeBatchSize must be greater than 0
 	ComputeBatchSize uint64
+
+	From uint64
+	To   *uint64
 }
 
 type ScryptParams struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,37 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/post/config"
+)
+
+func TestTotalFiles(t *testing.T) {
+	r := require.New(t)
+
+	opts := config.InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+	}
+	r.Equal(100, opts.TotalFiles(128))
+
+	opts = config.InitOpts{
+		NumUnits:    1,
+		MaxFileSize: 2048,
+	}
+	r.Equal(1, opts.TotalFiles(128))
+
+	opts = config.InitOpts{
+		NumUnits:    1,
+		MaxFileSize: 10000000,
+	}
+	r.Equal(1, opts.TotalFiles(128))
+
+	opts = config.InitOpts{
+		NumUnits:    0,
+		MaxFileSize: 10000000,
+	}
+	r.Equal(0, opts.TotalFiles(128))
+}

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -234,19 +234,32 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	}
 	defer init.mtx.Unlock()
 
-	layout := deriveFilesLayout(init.cfg, init.opts)
+	layout, err := deriveFilesLayout(init.cfg, init.opts)
+	if err != nil {
+		return err
+	}
+
 	init.logger.Info("initialization started",
 		zap.String("datadir", init.opts.DataDir),
 		zap.Uint32("numUnits", init.opts.NumUnits),
 		zap.Uint64("maxFileSize", init.opts.MaxFileSize),
 		zap.Uint64("labelsPerUnit", init.cfg.LabelsPerUnit),
+		zap.Uint64("from", layout.From),
+		zap.Uint64("to", layout.To),
+		zap.Uint64("total", layout.To-layout.From),
 	)
+
+	firstFileIndex := int(layout.From / layout.FileNumLabels)
+	lastFileIndex := firstFileIndex + int(layout.NumFiles)
+
 	init.logger.Info("initialization file layout",
 		zap.Uint("numFiles", layout.NumFiles),
 		zap.Uint64("labelsPerFile", layout.FileNumLabels),
 		zap.Uint64("labelsLastFile", layout.LastFileNumLabels),
+		zap.Int("firstFileIndex", firstFileIndex),
+		zap.Int("lastFileIndex", lastFileIndex),
 	)
-	if err := init.removeRedundantFiles(layout); err != nil {
+	if err := init.removeRedundantFiles(*layout); err != nil {
 		return err
 	}
 
@@ -266,7 +279,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	}
 	defer wo.Close()
 
-	for i := 0; i < int(layout.NumFiles); i++ {
+	for i := firstFileIndex; i < lastFileIndex; i++ {
 		fileOffset := uint64(i) * layout.FileNumLabels
 		fileNumLabels := layout.FileNumLabels
 		if i == int(layout.NumFiles)-1 {
@@ -590,6 +603,7 @@ func (init *Initializer) saveMetadata() error {
 		NumUnits:        init.opts.NumUnits,
 		MaxFileSize:     init.opts.MaxFileSize,
 		Nonce:           init.nonce.Load(),
+		NonceValue:      init.nonceValue,
 		LastPosition:    init.lastPosition.Load(),
 	}
 	return SaveMetadata(init.opts.DataDir, &v)

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -244,19 +244,15 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 		zap.Uint32("numUnits", init.opts.NumUnits),
 		zap.Uint64("maxFileSize", init.opts.MaxFileSize),
 		zap.Uint64("labelsPerUnit", init.cfg.LabelsPerUnit),
-		zap.Uint64("from", layout.From),
-		zap.Uint64("to", layout.To),
-		zap.Uint64("total", layout.To-layout.From),
 	)
 
-	firstFileIndex := int(layout.From / layout.FileNumLabels)
-	lastFileIndex := firstFileIndex + int(layout.NumFiles)
+	lastFileIndex := layout.FirstFileIdx + int(layout.NumFiles)
 
 	init.logger.Info("initialization file layout",
 		zap.Uint("numFiles", layout.NumFiles),
 		zap.Uint64("labelsPerFile", layout.FileNumLabels),
 		zap.Uint64("labelsLastFile", layout.LastFileNumLabels),
-		zap.Int("firstFileIndex", firstFileIndex),
+		zap.Int("firstFileIndex", layout.FirstFileIdx),
 		zap.Int("lastFileIndex", lastFileIndex),
 	)
 	if err := init.removeRedundantFiles(layout); err != nil {
@@ -279,7 +275,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	}
 	defer wo.Close()
 
-	for i := firstFileIndex; i < lastFileIndex; i++ {
+	for i := layout.FirstFileIdx; i < lastFileIndex; i++ {
 		fileOffset := uint64(i) * layout.FileNumLabels
 		fileNumLabels := layout.FileNumLabels
 		if i == int(layout.NumFiles)-1 {

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -246,7 +246,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 		zap.Uint64("labelsPerUnit", init.cfg.LabelsPerUnit),
 	)
 
-	lastFileIndex := layout.FirstFileIdx + int(layout.NumFiles)
+	lastFileIndex := layout.FirstFileIdx + int(layout.NumFiles) - 1
 
 	init.logger.Info("initialization file layout",
 		zap.Uint("numFiles", layout.NumFiles),
@@ -275,10 +275,10 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	}
 	defer wo.Close()
 
-	for i := layout.FirstFileIdx; i < lastFileIndex; i++ {
+	for i := layout.FirstFileIdx; i <= lastFileIndex; i++ {
 		fileOffset := uint64(i) * layout.FileNumLabels
 		fileNumLabels := layout.FileNumLabels
-		if i == int(layout.NumFiles)-1 {
+		if i == lastFileIndex {
 			fileNumLabels = layout.LastFileNumLabels
 		}
 

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -255,7 +255,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 		zap.Int("firstFileIndex", layout.FirstFileIdx),
 		zap.Int("lastFileIndex", lastFileIndex),
 	)
-	if err := init.removeRedundantFiles(layout); err != nil {
+	if err := removeRedundantFiles(init.cfg, init.opts, init.logger); err != nil {
 		return err
 	}
 
@@ -334,22 +334,32 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	return fmt.Errorf("no nonce found")
 }
 
-func (init *Initializer) removeRedundantFiles(layout filesLayout) error {
-	numFiles, err := init.diskState.NumFilesWritten()
+func removeRedundantFiles(cfg config.Config, opts config.InitOpts, logger *zap.Logger) error {
+	// Go over all postdata_N.bin files in the data directory and remove the ones that are not needed.
+	// The files with indices from 0 to init.opts.TotalFiles(init.cfg.LabelsPerUnit) - 1 are preserved.
+	// The rest are redundant and can be removed.
+	maxFileIndex := opts.TotalFiles(cfg.LabelsPerUnit) - 1
+	logger.Debug("attempting to remove redundant files above index", zap.Int("maxFileIndex", maxFileIndex))
+
+	files, err := os.ReadDir(opts.DataDir)
 	if err != nil {
 		return err
 	}
-
-	for i := int(layout.NumFiles); i < numFiles; i++ {
-		name := shared.InitFileName(i)
-		init.logger.Info("initialization: removing redundant file",
-			zap.String("fileName", name),
-		)
-		if err := init.RemoveFile(name); err != nil {
-			return err
+	for _, file := range files {
+		name := file.Name()
+		fileIndex, err := shared.ParseFileIndex(name)
+		if err != nil && name != metadataFileName {
+			logger.Warn("found unrecognized file", zap.String("fileName", name))
+			continue
+		}
+		if fileIndex > maxFileIndex {
+			logger.Info("removing redundant file", zap.String("fileName", name))
+			path := filepath.Join(opts.DataDir, name)
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("failed to delete file (%v): %w", path, err)
+			}
 		}
 	}
-
 	return nil
 }
 
@@ -379,19 +389,11 @@ func (init *Initializer) Reset() error {
 		}
 		name := file.Name()
 		if shared.IsInitFile(info) || name == metadataFileName {
-			if err := init.RemoveFile(name); err != nil {
-				return err
+			path := filepath.Join(init.opts.DataDir, name)
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("failed to delete file (%v): %w", path, err)
 			}
 		}
-	}
-
-	return nil
-}
-
-func (init *Initializer) RemoveFile(name string) error {
-	path := filepath.Join(init.opts.DataDir, name)
-	if err := os.Remove(path); err != nil {
-		return fmt.Errorf("failed to delete file (%v): %w", path, err)
 	}
 
 	return nil

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -259,7 +259,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 		zap.Int("firstFileIndex", firstFileIndex),
 		zap.Int("lastFileIndex", lastFileIndex),
 	)
-	if err := init.removeRedundantFiles(*layout); err != nil {
+	if err := init.removeRedundantFiles(layout); err != nil {
 		return err
 	}
 

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -962,3 +962,33 @@ func TestInitializeLastFileIsSmaller(t *testing.T) {
 	r.NoError(err)
 	r.Equal(cfg.UnitSize(), uint64(file.Size()))
 }
+
+func TestRemoveRedundantFiles(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	opts := config.DefaultInitOpts()
+	opts.DataDir = t.TempDir()
+	opts.NumUnits = 3
+	opts.MaxFileSize = 2 * cfg.UnitSize()
+
+	expectedFilesCount := opts.TotalFiles(cfg.LabelsPerUnit)
+	// Create 2 redundant files
+	for i := 0; i < expectedFilesCount+2; i++ {
+		f, err := os.Create(filepath.Join(opts.DataDir, shared.InitFileName(i)))
+		require.NoError(t, err)
+		_, err = f.Write([]byte("test"))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	removeRedundantFiles(cfg, opts, zap.NewNop())
+
+	files, err := os.ReadDir(opts.DataDir)
+	require.NoError(t, err)
+	require.Len(t, files, expectedFilesCount)
+
+	for i := 0; i < expectedFilesCount; i++ {
+		_, err := os.Stat(filepath.Join(opts.DataDir, shared.InitFileName(i)))
+		require.NoError(t, err)
+	}
+}

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -911,9 +910,9 @@ func TestInitializeSubset(t *testing.T) {
 	r.NoError(err)
 
 	// Verify that postdata_3.bin from both initializations contain the same data
-	fullPostdata3, err := ioutil.ReadFile(filepath.Join(opts.DataDir, "postdata_3.bin"))
+	fullPostdata3, err := os.ReadFile(filepath.Join(opts.DataDir, "postdata_3.bin"))
 	r.NoError(err)
-	subsetPostdata3, err := ioutil.ReadFile(filepath.Join(optsSubset.DataDir, "postdata_3.bin"))
+	subsetPostdata3, err := os.ReadFile(filepath.Join(optsSubset.DataDir, "postdata_3.bin"))
 	r.NoError(err)
 	r.Equal(fullPostdata3, subsetPostdata3)
 }

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -857,7 +857,7 @@ func TestInitializeSubset(t *testing.T) {
 
 	opts := config.DefaultInitOpts()
 	opts.DataDir = t.TempDir()
-	opts.NumUnits = 10
+	opts.NumUnits = 20
 	opts.MaxFileSize = cfg.LabelsPerUnit * 2 * uint64(config.BytesPerLabel()) // 2 units per file
 	opts.ProviderID = int(CPUProviderID())
 	opts.Scrypt.N = 2
@@ -897,17 +897,21 @@ func TestInitializeSubset(t *testing.T) {
 	r.NoError(err)
 	r.True(bytes.Contains(fullData, subsetData))
 
-	// Verify that the subset contains file postdata_3.bin, but not postdata_0.bin, postdata_1.bin, postdata_2.bin and postdata_4.bin
+	// Verify that the subset contains files 3 and 4, but not 0-2 and 5
 	_, err = os.Stat(filepath.Join(optsSubset.DataDir, "postdata_0.bin"))
 	r.ErrorIs(err, os.ErrNotExist)
 	_, err = os.Stat(filepath.Join(optsSubset.DataDir, "postdata_1.bin"))
 	r.ErrorIs(err, os.ErrNotExist)
 	_, err = os.Stat(filepath.Join(optsSubset.DataDir, "postdata_2.bin"))
 	r.ErrorIs(err, os.ErrNotExist)
-	_, err = os.Stat(filepath.Join(optsSubset.DataDir, "postdata_4.bin"))
-	r.ErrorIs(err, os.ErrNotExist)
+
 	_, err = os.Stat(filepath.Join(optsSubset.DataDir, "postdata_3.bin"))
 	r.NoError(err)
+	_, err = os.Stat(filepath.Join(optsSubset.DataDir, "postdata_4.bin"))
+	r.NoError(err)
+
+	_, err = os.Stat(filepath.Join(optsSubset.DataDir, "postdata_5.bin"))
+	r.ErrorIs(err, os.ErrNotExist)
 
 	// Verify that postdata_3.bin from both initializations contain the same data
 	fullPostdata3, err := os.ReadFile(filepath.Join(opts.DataDir, "postdata_3.bin"))
@@ -915,4 +919,11 @@ func TestInitializeSubset(t *testing.T) {
 	subsetPostdata3, err := os.ReadFile(filepath.Join(optsSubset.DataDir, "postdata_3.bin"))
 	r.NoError(err)
 	r.Equal(fullPostdata3, subsetPostdata3)
+
+	// Verify that postdata_4.bin from both initializations contain the same data
+	fullPostdata4, err := os.ReadFile(filepath.Join(opts.DataDir, "postdata_4.bin"))
+	r.NoError(err)
+	subsetPostdata4, err := os.ReadFile(filepath.Join(optsSubset.DataDir, "postdata_4.bin"))
+	r.NoError(err)
+	r.Equal(fullPostdata4, subsetPostdata4)
 }

--- a/initialization/layout.go
+++ b/initialization/layout.go
@@ -2,7 +2,6 @@ package initialization
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/spacemeshos/post/config"
 )
@@ -16,10 +15,9 @@ type filesLayout struct {
 
 func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, error) {
 	maxFileNumLabels := opts.MaxFileNumLabels()
-	totalLabels := uint64(opts.NumUnits) * uint64(cfg.LabelsPerUnit)
 
 	firstFileIdx := opts.FromFileIdx
-	lastFileIdx := TotalFiles(cfg, opts) - 1
+	lastFileIdx := opts.TotalFiles(cfg.LabelsPerUnit) - 1
 
 	if opts.ToFileIdx != nil {
 		if *opts.ToFileIdx < 0 {
@@ -31,14 +29,14 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, er
 		lastFileIdx = *opts.ToFileIdx
 	}
 
-	lastFileNumLabels := maxFileNumLabels
-	labelsLeft := totalLabels - firstLabelInFile(lastFileIdx, opts)
-	if labelsLeft < maxFileNumLabels {
-		lastFileNumLabels = labelsLeft
-	}
-
 	if firstFileIdx > lastFileIdx {
 		return filesLayout{}, fmt.Errorf("invalid range: last file index (%v) must be greater then first (%v)", lastFileIdx, firstFileIdx)
+	}
+
+	lastFileNumLabels := maxFileNumLabels
+	labelsLeft := opts.TotalLabels(cfg.LabelsPerUnit) - firstLabelInFile(lastFileIdx, opts)
+	if labelsLeft < maxFileNumLabels {
+		lastFileNumLabels = labelsLeft
 	}
 
 	numFiles := lastFileIdx - firstFileIdx + 1
@@ -53,9 +51,4 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, er
 
 func firstLabelInFile(fileIdx int, opts config.InitOpts) uint64 {
 	return uint64(fileIdx) * opts.MaxFileNumLabels()
-}
-
-func TotalFiles(cfg config.Config, opts config.InitOpts) int {
-	totalLabels := uint64(opts.NumUnits) * uint64(cfg.LabelsPerUnit)
-	return int(math.Ceil(float64(totalLabels) / float64(opts.MaxFileNumLabels())))
 }

--- a/initialization/layout.go
+++ b/initialization/layout.go
@@ -15,7 +15,7 @@ type filesLayout struct {
 	LastFileNumLabels uint64
 }
 
-func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (*filesLayout, error) {
+func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, error) {
 	maxFileSizeBits := opts.MaxFileSize * 8
 	maxFileNumLabels := maxFileSizeBits / uint64(config.BitsPerLabel)
 	totalLabels := uint64(opts.NumUnits) * uint64(cfg.LabelsPerUnit)
@@ -28,11 +28,11 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (*filesLayout, e
 	}
 
 	if start >= end {
-		return nil, fmt.Errorf("invalid range: start (%v) must be less then end (%v)", start, end)
+		return filesLayout{}, fmt.Errorf("invalid range: start (%v) must be less then end (%v)", start, end)
 	}
 	// Avoid starting in the middle of a file
 	if start%maxFileNumLabels != 0 {
-		return nil, fmt.Errorf("invalid range: start (%v) must be a multiple of: %v", start, maxFileNumLabels)
+		return filesLayout{}, fmt.Errorf("invalid range: start (%v) must be a multiple of: %v", start, maxFileNumLabels)
 	}
 
 	numLabels := end - start
@@ -45,7 +45,7 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (*filesLayout, e
 		lastFileNumLabels = remainder
 	}
 
-	return &filesLayout{
+	return filesLayout{
 		From:              start,
 		To:                end,
 		NumFiles:          uint(numFiles),

--- a/initialization/layout.go
+++ b/initialization/layout.go
@@ -1,17 +1,41 @@
 package initialization
 
-import "github.com/spacemeshos/post/config"
+import (
+	"fmt"
+
+	"github.com/spacemeshos/post/config"
+)
 
 type filesLayout struct {
+	From uint64
+	To   uint64
+
 	NumFiles          uint
 	FileNumLabels     uint64
 	LastFileNumLabels uint64
 }
 
-func deriveFilesLayout(cfg config.Config, opts config.InitOpts) filesLayout {
+func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (*filesLayout, error) {
 	maxFileSizeBits := opts.MaxFileSize * 8
 	maxFileNumLabels := maxFileSizeBits / uint64(config.BitsPerLabel)
-	numLabels := cfg.LabelsPerUnit * uint64(opts.NumUnits)
+	totalLabels := uint64(opts.NumUnits) * uint64(cfg.LabelsPerUnit)
+
+	start := opts.From
+	end := totalLabels
+
+	if opts.To != nil {
+		end = *opts.To
+	}
+
+	if start >= end {
+		return nil, fmt.Errorf("invalid range: start (%v) must be less then end (%v)", start, end)
+	}
+	// Avoid starting in the middle of a file
+	if start%maxFileNumLabels != 0 {
+		return nil, fmt.Errorf("invalid range: start (%v) must be a multiple of: %v", start, maxFileNumLabels)
+	}
+
+	numLabels := end - start
 	numFiles := numLabels / maxFileNumLabels
 
 	lastFileNumLabels := maxFileNumLabels
@@ -21,9 +45,11 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) filesLayout {
 		lastFileNumLabels = remainder
 	}
 
-	return filesLayout{
+	return &filesLayout{
+		From:              start,
+		To:                end,
 		NumFiles:          uint(numFiles),
 		FileNumLabels:     maxFileNumLabels,
 		LastFileNumLabels: lastFileNumLabels,
-	}
+	}, nil
 }

--- a/initialization/layout.go
+++ b/initialization/layout.go
@@ -2,6 +2,7 @@ package initialization
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/spacemeshos/post/config"
 )
@@ -18,10 +19,7 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, er
 	totalLabels := uint64(opts.NumUnits) * uint64(cfg.LabelsPerUnit)
 
 	firstFileIdx := opts.FromFileIdx
-	lastFileIdx := int(totalLabels/maxFileNumLabels) - 1
-	if totalLabels%maxFileNumLabels > 0 {
-		lastFileIdx++
-	}
+	lastFileIdx := TotalFiles(cfg, opts) - 1
 
 	if opts.ToFileIdx != nil {
 		if *opts.ToFileIdx < 0 {
@@ -55,4 +53,9 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, er
 
 func firstLabelInFile(fileIdx int, opts config.InitOpts) uint64 {
 	return uint64(fileIdx) * opts.MaxFileNumLabels()
+}
+
+func TotalFiles(cfg config.Config, opts config.InitOpts) int {
+	totalLabels := uint64(opts.NumUnits) * uint64(cfg.LabelsPerUnit)
+	return int(math.Ceil(float64(totalLabels) / float64(opts.MaxFileNumLabels())))
 }

--- a/initialization/layout.go
+++ b/initialization/layout.go
@@ -24,10 +24,13 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, er
 	}
 
 	if opts.ToFileIdx != nil {
-		if *opts.ToFileIdx <= 0 {
+		if *opts.ToFileIdx < 0 {
 			return filesLayout{}, fmt.Errorf("invalid range: opts.ToFileIdx (%v) must be greater then 0", *opts.ToFileIdx)
 		}
-		lastFileIdx = *opts.ToFileIdx - 1
+		if *opts.ToFileIdx > lastFileIdx {
+			return filesLayout{}, fmt.Errorf("invalid range: opts.ToFileIdx (%v) cannot be greater then %v", *opts.ToFileIdx, lastFileIdx)
+		}
+		lastFileIdx = *opts.ToFileIdx
 	}
 
 	lastFileNumLabels := maxFileNumLabels

--- a/initialization/layout_test.go
+++ b/initialization/layout_test.go
@@ -162,3 +162,30 @@ func TestCustomToPartialLastFile(t *testing.T) {
 	r.Equal(256, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }
+
+func TestTotalFiles(t *testing.T) {
+	r := require.New(t)
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+
+	r.Equal(100, TotalFiles(cfg, InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+	}))
+
+	r.Equal(1, TotalFiles(cfg, InitOpts{
+		NumUnits:    1,
+		MaxFileSize: 2048,
+	}))
+
+	r.Equal(1, TotalFiles(cfg, InitOpts{
+		NumUnits:    1,
+		MaxFileSize: 10000000,
+	}))
+
+	r.Equal(0, TotalFiles(cfg, InitOpts{
+		NumUnits:    0,
+		MaxFileSize: 10000000,
+	}))
+}

--- a/initialization/layout_test.go
+++ b/initialization/layout_test.go
@@ -69,7 +69,7 @@ func TestCustomTo(t *testing.T) {
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
 	r.EqualValues(0, layout.FirstFileIdx)
-	r.Equal(2, int(layout.NumFiles))
+	r.Equal(3, int(layout.NumFiles))
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }
@@ -91,7 +91,7 @@ func TestCustomFromAndTo(t *testing.T) {
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
 	r.EqualValues(1, layout.FirstFileIdx)
-	r.Equal(1, int(layout.NumFiles))
+	r.Equal(2, int(layout.NumFiles))
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }
@@ -100,7 +100,7 @@ func TestInvalidRange(t *testing.T) {
 	cfg := Config{
 		LabelsPerUnit: 128,
 	}
-	to := 1
+	to := 0
 	opts := InitOpts{
 		NumUnits:    100,
 		MaxFileSize: 2048,
@@ -112,11 +112,26 @@ func TestInvalidRange(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestToCannotBeZero(t *testing.T) {
+func TestToCannotBeNegative(t *testing.T) {
 	cfg := Config{
 		LabelsPerUnit: 128,
 	}
-	to := 0
+	to := -1
+	opts := InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+		ToFileIdx:   &to,
+	}
+
+	_, err := deriveFilesLayout(cfg, opts)
+	require.Error(t, err)
+}
+
+func TestToOutOfRange(t *testing.T) {
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	to := 1000000
 	opts := InitOpts{
 		NumUnits:    100,
 		MaxFileSize: 2048,
@@ -133,7 +148,7 @@ func TestCustomToPartialLastFile(t *testing.T) {
 	cfg := Config{
 		LabelsPerUnit: 128,
 	}
-	to := 50
+	to := 49
 	opts := InitOpts{
 		MaxFileSize: 4096, // 2 units per file
 		NumUnits:    99,   // last file will be partial

--- a/initialization/layout_test.go
+++ b/initialization/layout_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMaxFileSize(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	cfg := Config{
@@ -34,6 +35,7 @@ func TestMaxFileSize(t *testing.T) {
 }
 
 func TestCustomFrom(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	cfg := Config{
@@ -54,6 +56,7 @@ func TestCustomFrom(t *testing.T) {
 }
 
 func TestCustomTo(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	cfg := Config{
@@ -75,6 +78,7 @@ func TestCustomTo(t *testing.T) {
 }
 
 func TestCustomFromAndTo(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	cfg := Config{
@@ -97,6 +101,7 @@ func TestCustomFromAndTo(t *testing.T) {
 }
 
 func TestInvalidRange(t *testing.T) {
+	t.Parallel()
 	cfg := Config{
 		LabelsPerUnit: 128,
 	}
@@ -113,6 +118,7 @@ func TestInvalidRange(t *testing.T) {
 }
 
 func TestToCannotBeNegative(t *testing.T) {
+	t.Parallel()
 	cfg := Config{
 		LabelsPerUnit: 128,
 	}
@@ -128,6 +134,7 @@ func TestToCannotBeNegative(t *testing.T) {
 }
 
 func TestToOutOfRange(t *testing.T) {
+	t.Parallel()
 	cfg := Config{
 		LabelsPerUnit: 128,
 	}
@@ -143,6 +150,7 @@ func TestToOutOfRange(t *testing.T) {
 }
 
 func TestCustomToPartialLastFile(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	cfg := Config{
@@ -161,31 +169,4 @@ func TestCustomToPartialLastFile(t *testing.T) {
 	r.Equal(50, int(layout.NumFiles))
 	r.Equal(256, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
-}
-
-func TestTotalFiles(t *testing.T) {
-	r := require.New(t)
-	cfg := Config{
-		LabelsPerUnit: 128,
-	}
-
-	r.Equal(100, TotalFiles(cfg, InitOpts{
-		NumUnits:    100,
-		MaxFileSize: 2048,
-	}))
-
-	r.Equal(1, TotalFiles(cfg, InitOpts{
-		NumUnits:    1,
-		MaxFileSize: 2048,
-	}))
-
-	r.Equal(1, TotalFiles(cfg, InitOpts{
-		NumUnits:    1,
-		MaxFileSize: 10000000,
-	}))
-
-	r.Equal(0, TotalFiles(cfg, InitOpts{
-		NumUnits:    0,
-		MaxFileSize: 10000000,
-	}))
 }

--- a/initialization/layout_test.go
+++ b/initialization/layout_test.go
@@ -1,0 +1,149 @@
+package initialization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxFileSize(t *testing.T) {
+	r := require.New(t)
+
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	opts := InitOpts{
+		NumUnits:    10,
+		MaxFileSize: 2048,
+	}
+
+	layout, err := deriveFilesLayout(cfg, opts)
+	r.NoError(err)
+	r.Equal(10, int(layout.NumFiles))
+	r.Equal(128, int(layout.FileNumLabels))
+	r.Equal(128, int(layout.LastFileNumLabels))
+
+	opts.MaxFileSize = 2000
+
+	layout, err = deriveFilesLayout(cfg, opts)
+	r.NoError(err)
+	r.Equal(10*128, 10*125+30)
+	r.Equal(11, int(layout.NumFiles))
+	r.Equal(125, int(layout.FileNumLabels))
+	r.Equal(30, int(layout.LastFileNumLabels))
+}
+
+func TestCustomFrom(t *testing.T) {
+	r := require.New(t)
+
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	opts := InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+		FromFileIdx: 1,
+	}
+
+	layout, err := deriveFilesLayout(cfg, opts)
+	r.NoError(err)
+	r.EqualValues(1, layout.FirstFileIdx)
+	r.Equal(99, int(layout.NumFiles)) // should skip the first file
+	r.Equal(128, int(layout.FileNumLabels))
+	r.Equal(128, int(layout.LastFileNumLabels))
+}
+
+func TestCustomTo(t *testing.T) {
+	r := require.New(t)
+
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	to := 2
+	opts := InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+		ToFileIdx:   &to,
+	}
+
+	layout, err := deriveFilesLayout(cfg, opts)
+	r.NoError(err)
+	r.EqualValues(0, layout.FirstFileIdx)
+	r.Equal(2, int(layout.NumFiles))
+	r.Equal(128, int(layout.FileNumLabels))
+	r.Equal(128, int(layout.LastFileNumLabels))
+}
+
+func TestCustomFromAndTo(t *testing.T) {
+	r := require.New(t)
+
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	to := 2
+	opts := InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+		FromFileIdx: 1,
+		ToFileIdx:   &to,
+	}
+
+	layout, err := deriveFilesLayout(cfg, opts)
+	r.NoError(err)
+	r.EqualValues(1, layout.FirstFileIdx)
+	r.Equal(1, int(layout.NumFiles))
+	r.Equal(128, int(layout.FileNumLabels))
+	r.Equal(128, int(layout.LastFileNumLabels))
+}
+
+func TestInvalidRange(t *testing.T) {
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	to := 1
+	opts := InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+		FromFileIdx: 1,
+		ToFileIdx:   &to,
+	}
+
+	_, err := deriveFilesLayout(cfg, opts)
+	require.Error(t, err)
+}
+
+func TestToCannotBeZero(t *testing.T) {
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	to := 0
+	opts := InitOpts{
+		NumUnits:    100,
+		MaxFileSize: 2048,
+		ToFileIdx:   &to,
+	}
+
+	_, err := deriveFilesLayout(cfg, opts)
+	require.Error(t, err)
+}
+
+func TestCustomToPartialLastFile(t *testing.T) {
+	r := require.New(t)
+
+	cfg := Config{
+		LabelsPerUnit: 128,
+	}
+	to := 50
+	opts := InitOpts{
+		MaxFileSize: 4096, // 2 units per file
+		NumUnits:    99,   // last file will be partial
+		ToFileIdx:   &to,
+	}
+
+	layout, err := deriveFilesLayout(cfg, opts)
+	r.NoError(err)
+	r.EqualValues(0, layout.FirstFileIdx)
+	r.Equal(50, int(layout.NumFiles))
+	r.Equal(256, int(layout.FileNumLabels))
+	r.Equal(128, int(layout.LastFileNumLabels))
+}

--- a/shared/post_metadata.go
+++ b/shared/post_metadata.go
@@ -23,6 +23,7 @@ type NonceValue []byte
 func (n NonceValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(n))
 }
+
 func (n *NonceValue) UnmarshalJSON(data []byte) (err error) {
 	var hexString string
 	if err = json.Unmarshal(data, &hexString); err != nil {

--- a/shared/post_metadata.go
+++ b/shared/post_metadata.go
@@ -2,7 +2,7 @@ package shared
 
 import (
 	"encoding/hex"
-	"fmt"
+	"encoding/json"
 )
 
 // PostMetadata is the data associated with the PoST init procedure, persisted in the datadir next to the init files.
@@ -20,24 +20,14 @@ type PostMetadata struct {
 
 type NonceValue []byte
 
-// Unmarshal JSON from hex format.
-func (n *NonceValue) UnmarshalJSON(data []byte) error {
-	if len(data) == 0 {
-		return nil
-	}
-	// trim quotes
-	data = data[1 : len(data)-1]
-	*n = make([]byte, hex.DecodedLen(len(data)))
-	_, err := hex.Decode(*n, data)
-	return err
-}
-
-// Marshal to JSON in hex format.
 func (n NonceValue) MarshalJSON() ([]byte, error) {
-	if n == nil {
-		return []byte{}, nil
+	return json.Marshal(hex.EncodeToString(n))
+}
+func (n *NonceValue) UnmarshalJSON(data []byte) (err error) {
+	var hexString string
+	if err = json.Unmarshal(data, &hexString); err != nil {
+		return
 	}
-	dst := make([]byte, hex.EncodedLen(len(n)))
-	hex.Encode(dst, n[:])
-	return []byte(fmt.Sprintf("\"%s\"", dst)), nil
+	*n, err = hex.DecodeString(hexString)
+	return
 }

--- a/shared/post_metadata.go
+++ b/shared/post_metadata.go
@@ -20,7 +20,7 @@ type PostMetadata struct {
 
 type NonceValue []byte
 
-// UnmarshalJSON from hex
+// Unmarshal JSON from hex format.
 func (n *NonceValue) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 {
 		return nil
@@ -32,7 +32,7 @@ func (n *NonceValue) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-// MarshalJSON to hex
+// Marshal to JSON in hex format.
 func (n NonceValue) MarshalJSON() ([]byte, error) {
 	if n == nil {
 		return []byte{}, nil

--- a/shared/post_metadata.go
+++ b/shared/post_metadata.go
@@ -1,5 +1,10 @@
 package shared
 
+import (
+	"encoding/hex"
+	"fmt"
+)
+
 // PostMetadata is the data associated with the PoST init procedure, persisted in the datadir next to the init files.
 type PostMetadata struct {
 	NodeId          []byte
@@ -8,6 +13,31 @@ type PostMetadata struct {
 	LabelsPerUnit uint64
 	NumUnits      uint32
 	MaxFileSize   uint64
-	Nonce         *uint64 `json:",omitempty"`
-	LastPosition  *uint64 `json:",omitempty"`
+	Nonce         *uint64    `json:",omitempty"`
+	NonceValue    NonceValue `json:",omitempty"`
+	LastPosition  *uint64    `json:",omitempty"`
+}
+
+type NonceValue []byte
+
+// UnmarshalJSON from hex
+func (n *NonceValue) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	// trim quotes
+	data = data[1 : len(data)-1]
+	*n = make([]byte, hex.DecodedLen(len(data)))
+	_, err := hex.Decode(*n, data)
+	return err
+}
+
+// MarshalJSON to hex
+func (n NonceValue) MarshalJSON() ([]byte, error) {
+	if n == nil {
+		return []byte{}, nil
+	}
+	dst := make([]byte, hex.EncodedLen(len(n)))
+	hex.Encode(dst, n[:])
+	return []byte(fmt.Sprintf("\"%s\"", dst)), nil
 }

--- a/shared/post_metadata_test.go
+++ b/shared/post_metadata_test.go
@@ -1,0 +1,23 @@
+package shared_test
+
+import (
+	"testing"
+
+	"github.com/spacemeshos/post/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalNonceValue(t *testing.T) {
+	n := shared.NonceValue{0x01, 0x02, 0x03}
+	data, err := n.MarshalJSON()
+	require.NoError(t, err)
+	require.EqualValues(t, `"010203"`, data)
+}
+
+func TestUnmarshalNonceValue(t *testing.T) {
+	data := `"010203"`
+	n := shared.NonceValue{}
+	err := n.UnmarshalJSON([]byte(data))
+	require.NoError(t, err)
+	require.Equal(t, shared.NonceValue{0x01, 0x02, 0x03}, n)
+}

--- a/shared/post_metadata_test.go
+++ b/shared/post_metadata_test.go
@@ -3,8 +3,9 @@ package shared_test
 import (
 	"testing"
 
-	"github.com/spacemeshos/post/shared"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/post/shared"
 )
 
 func TestMarshalNonceValue(t *testing.T) {

--- a/shared/util.go
+++ b/shared/util.go
@@ -11,19 +11,20 @@ func InitFileName(index int) string {
 	return fmt.Sprintf("postdata_%d.bin", index)
 }
 
+func ParseFileIndex(fileName string) (int, error) {
+	re := regexp.MustCompile(`^postdata_(\d*).bin$`)
+	matches := re.FindStringSubmatch(fileName)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("invalid file name: %s", fileName)
+	}
+	return strconv.Atoi(matches[1])
+}
+
 func IsInitFile(file os.FileInfo) bool {
 	if file.IsDir() {
 		return false
 	}
 
-	re := regexp.MustCompile("postdata_(.*).bin")
-	matches := re.FindStringSubmatch(file.Name())
-	if len(matches) != 2 {
-		return false
-	}
-	if _, err := strconv.Atoi(matches[1]); err != nil {
-		return false
-	}
-
-	return true
+	_, err := ParseFileIndex(file.Name())
+	return err == nil
 }


### PR DESCRIPTION
## Motivation
It is now possible to initialize a subset of POS data with `postcli`. The initialization can be split on file boundary (i.e. files (0-N), (N+1 - M), etc.)

## Changes
Added 2 new arguments to `postcli`:
```
-fromFile int
        index of the first file to init (inclusive)
-toFile int
        index of the last file to init (inclusive). Will init to the end of declared space if not provided.
```

Added the value of found nonce to metadata in order to be able to select the best nonce. The operator combining separately initialized data will need to manually pick the best CRF nonce if they wish to have the best possible nonce. Details in the updated readme.

