### PR TITLE
Fix incorrect error message

### DIFF
--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -532,7 +532,7 @@ func (init *Initializer) initFile(ctx context.Context, wo, woReference *oracle.W
 				Index:      endPosition,
 				Commitment: init.commitment,
 				Expected:   reference.Output,
-				Actual:     res.Output[batchSize-postrs.LabelLength:],
+				Actual:     res.Output[(batchSize-1)*postrs.LabelLength:],
 			}
 		}
 

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -859,6 +859,11 @@ func TestWrongLabelsDetected(t *testing.T) {
 	require.ErrorAs(t, err, &errWrongLabels)
 	require.Equal(t, oracle.CommitmentBytes(nodeId, commitmentAtxId), errWrongLabels.Commitment)
 	require.Equal(t, uint64(1<<12-1), errWrongLabels.Index)
+	reference, err := init.referenceOracle.Position(errWrongLabels.Index)
+	require.NoError(t, err)
+	require.Equal(t, reference.Output, errWrongLabels.Expected)
+	require.Equal(t, len(reference.Output), len(errWrongLabels.Actual))
+	require.NotEqual(t, reference.Output, errWrongLabels.Actual)
 
 	require.Equal(t, uint64(0), init.NumLabelsWritten())
 }


### PR DESCRIPTION
Instead of spewing out basically the whole batch of calculated labels only print the mismatched label.

Added more assertions to ensure that the error message is correct when it happens.