### PR TITLE
Improve VRF lookup past init data

### DIFF
--- a/cmd/postcli/README.md
+++ b/cmd/postcli/README.md
@@ -147,17 +147,20 @@ in each `post_metadata.json` of every subset. Given two files:
 ```json
 ... (other fields omitted for brevity)
 "Nonce": 12345
-"NonceValue": 0000ffda94993723a980bf557509773e
+"NonceValue": "0000ffda94993723a980bf557509773e"
 ```
 
 ```json
 ... (other fields omitted for brevity)
 "Nonce": 98765
-"NonceValue": 0000488e171389cce69344d68b66f6b4
+"NonceValue": "0000488e171389cce69344d68b66f6b4"
 ```
 
 The nonce in the second file is the global minimum since its value is smaller than the first one. The operator is **required** to find the
 smallest VRF nonce by hand and ensure that its index and value are in the `postdata_metadata.json` of the merged directory on the target machine.
+
+Not every chunk will contain a VRF nonce in its `postdata_metadata.json`, but at least one should. If for the very unlikely case that no VRF nonce
+was found in any chunk the operator can run `postcli` again **after merging the data** without `-fromFile` and `-toFile` flags to find a VRF nonce.
 
 ## Troubleshooting
 

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -309,6 +309,11 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	}
 
 	if init.nonce.Load() != nil {
+		init.logger.Info("initialization: completed, found nonce", zap.Uint64("nonce", *init.nonce.Load()))
+		return nil
+	}
+	if layout.FirstFileIdx > 0 || layout.LastFileIdx < init.opts.TotalFiles(init.cfg.LabelsPerUnit)-1 {
+		init.logger.Info("initialization: no nonce found while computing labels")
 		return nil
 	}
 

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -255,14 +255,11 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 		zap.Uint64("labelsPerUnit", init.cfg.LabelsPerUnit),
 	)
 
-	lastFileIndex := layout.FirstFileIdx + int(layout.NumFiles) - 1
-
 	init.logger.Info("initialization file layout",
-		zap.Uint("numFiles", layout.NumFiles),
 		zap.Uint64("labelsPerFile", layout.FileNumLabels),
 		zap.Uint64("labelsLastFile", layout.LastFileNumLabels),
 		zap.Int("firstFileIndex", layout.FirstFileIdx),
-		zap.Int("lastFileIndex", lastFileIndex),
+		zap.Int("lastFileIndex", layout.LastFileIdx),
 	)
 	if err := removeRedundantFiles(init.cfg, init.opts, init.logger); err != nil {
 		return err
@@ -299,10 +296,10 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 		defer woReference.Close()
 	}
 
-	for i := layout.FirstFileIdx; i <= lastFileIndex; i++ {
+	for i := layout.FirstFileIdx; i <= layout.LastFileIdx; i++ {
 		fileOffset := uint64(i) * layout.FileNumLabels
 		fileNumLabels := layout.FileNumLabels
-		if i == lastFileIndex {
+		if i == layout.LastFileIdx {
 			fileNumLabels = layout.LastFileNumLabels
 		}
 

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -312,7 +312,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 		init.logger.Info("initialization: completed, found nonce", zap.Uint64("nonce", *init.nonce.Load()))
 		return nil
 	}
-	if layout.FirstFileIdx > 0 || layout.LastFileIdx < init.opts.TotalFiles(init.cfg.LabelsPerUnit)-1 {
+	if layout.NumFiles() < init.opts.TotalFiles(init.cfg.LabelsPerUnit) {
 		init.logger.Info("initialization: no nonce found while computing labels")
 		return nil
 	}

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -514,7 +514,7 @@ func TestInitialize_RedundantFiles(t *testing.T) {
 		r.NoError(err)
 		layout, err := deriveFilesLayout(cfg, opts)
 		r.NoError(err)
-		r.Equal(int(layout.NumFiles), numFiles)
+		r.Equal(layout.LastFileIdx+1, numFiles)
 
 		r.NoError(newInit.Initialize(ctx))
 
@@ -522,8 +522,9 @@ func TestInitialize_RedundantFiles(t *testing.T) {
 		r.NoError(err)
 		newLayout, err := deriveFilesLayout(cfg, newOpts)
 		r.NoError(err)
-		r.Equal(int(newLayout.NumFiles), numFiles)
-		r.Less(newLayout.NumFiles, layout.NumFiles)
+		r.Equal(newLayout.LastFileIdx+1, numFiles)
+		r.Equal(0, newLayout.FirstFileIdx)
+		r.Less(newLayout.LastFileIdx, layout.LastFileIdx)
 
 		cancel()
 		eg.Wait()
@@ -576,7 +577,8 @@ func TestInitialize_MultipleFiles(t *testing.T) {
 
 			layout, err := deriveFilesLayout(cfg, opts)
 			require.NoError(t, err)
-			require.Equal(t, numFiles, int(layout.NumFiles))
+			require.Equal(t, 0, layout.FirstFileIdx)
+			require.Equal(t, numFiles-1, layout.LastFileIdx)
 
 			init, err := NewInitializer(
 				WithNodeId(nodeId),

--- a/initialization/layout.go
+++ b/initialization/layout.go
@@ -8,7 +8,7 @@ import (
 
 type filesLayout struct {
 	FirstFileIdx      int
-	NumFiles          uint
+	LastFileIdx       int
 	FileNumLabels     uint64
 	LastFileNumLabels uint64
 }
@@ -39,11 +39,9 @@ func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, er
 		lastFileNumLabels = labelsLeft
 	}
 
-	numFiles := lastFileIdx - firstFileIdx + 1
-
 	return filesLayout{
 		FirstFileIdx:      firstFileIdx,
-		NumFiles:          uint(numFiles),
+		LastFileIdx:       lastFileIdx,
 		FileNumLabels:     maxFileNumLabels,
 		LastFileNumLabels: lastFileNumLabels,
 	}, nil

--- a/initialization/layout.go
+++ b/initialization/layout.go
@@ -13,6 +13,10 @@ type filesLayout struct {
 	LastFileNumLabels uint64
 }
 
+func (l filesLayout) NumFiles() int {
+	return l.LastFileIdx - l.FirstFileIdx + 1
+}
+
 func deriveFilesLayout(cfg config.Config, opts config.InitOpts) (filesLayout, error) {
 	maxFileNumLabels := opts.MaxFileNumLabels()
 

--- a/initialization/layout_test.go
+++ b/initialization/layout_test.go
@@ -74,7 +74,7 @@ func TestCustomTo(t *testing.T) {
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
 	r.Equal(0, layout.FirstFileIdx)
-	r.Equal(3, int(layout.LastFileIdx-layout.FirstFileIdx+1))
+	r.Equal(2, layout.LastFileIdx)
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }
@@ -97,7 +97,7 @@ func TestCustomFromAndTo(t *testing.T) {
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
 	r.Equal(1, layout.FirstFileIdx)
-	r.Equal(2, int(layout.LastFileIdx-layout.FirstFileIdx+1))
+	r.Equal(2, layout.LastFileIdx)
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }

--- a/initialization/layout_test.go
+++ b/initialization/layout_test.go
@@ -20,7 +20,8 @@ func TestMaxFileSize(t *testing.T) {
 
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
-	r.Equal(10, int(layout.NumFiles))
+	r.Equal(0, layout.FirstFileIdx)
+	r.Equal(9, layout.LastFileIdx)
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 
@@ -29,7 +30,8 @@ func TestMaxFileSize(t *testing.T) {
 	layout, err = deriveFilesLayout(cfg, opts)
 	r.NoError(err)
 	r.Equal(10*128, 10*125+30)
-	r.Equal(11, int(layout.NumFiles))
+	r.Equal(0, layout.FirstFileIdx)
+	r.Equal(10, layout.LastFileIdx)
 	r.Equal(125, int(layout.FileNumLabels))
 	r.Equal(30, int(layout.LastFileNumLabels))
 }
@@ -49,8 +51,8 @@ func TestCustomFrom(t *testing.T) {
 
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
-	r.EqualValues(1, layout.FirstFileIdx)
-	r.Equal(99, int(layout.NumFiles)) // should skip the first file
+	r.Equal(1, layout.FirstFileIdx) // should skip the first file
+	r.Equal(99, layout.LastFileIdx)
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }
@@ -71,8 +73,8 @@ func TestCustomTo(t *testing.T) {
 
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
-	r.EqualValues(0, layout.FirstFileIdx)
-	r.Equal(3, int(layout.NumFiles))
+	r.Equal(0, layout.FirstFileIdx)
+	r.Equal(3, int(layout.LastFileIdx-layout.FirstFileIdx+1))
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }
@@ -94,8 +96,8 @@ func TestCustomFromAndTo(t *testing.T) {
 
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
-	r.EqualValues(1, layout.FirstFileIdx)
-	r.Equal(2, int(layout.NumFiles))
+	r.Equal(1, layout.FirstFileIdx)
+	r.Equal(2, int(layout.LastFileIdx-layout.FirstFileIdx+1))
 	r.Equal(128, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }
@@ -165,8 +167,8 @@ func TestCustomToPartialLastFile(t *testing.T) {
 
 	layout, err := deriveFilesLayout(cfg, opts)
 	r.NoError(err)
-	r.EqualValues(0, layout.FirstFileIdx)
-	r.Equal(50, int(layout.NumFiles))
+	r.Equal(0, layout.FirstFileIdx)
+	r.Equal(49, layout.LastFileIdx)
 	r.Equal(256, int(layout.FileNumLabels))
 	r.Equal(128, int(layout.LastFileNumLabels))
 }


### PR DESCRIPTION
Closes #187 

No additional command line flags are required. The initializer will never look outside the range it initializes if it was instructed to initialize less than the whole range.