### PR TITLE
Verify key.bin against NodeID in metadata

### DIFF
--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -168,6 +168,7 @@ func main() {
 
 	if verifyPos {
 		cmdVerifyPos(opts, fraction, logger)
+		os.Exit(0)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -318,7 +319,6 @@ func cmdVerifyPos(opts config.InitOpts, fraction float64, logger *zap.Logger) {
 	switch {
 	case err == nil:
 		log.Println("cli: POS data is valid")
-		os.Exit(0)
 	case errors.Is(err, postrs.ErrInvalidPos):
 		log.Fatalf("cli: %v\n", err)
 	default:

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -407,7 +407,7 @@ func removeRedundantFiles(cfg config.Config, opts config.InitOpts, logger *zap.L
 	for _, file := range files {
 		name := file.Name()
 		fileIndex, err := shared.ParseFileIndex(name)
-		if err != nil && name != metadataFileName {
+		if err != nil && name != MetadataFileName {
 			logger.Warn("found unrecognized file", zap.String("fileName", name))
 			continue
 		}
@@ -457,7 +457,7 @@ func (init *Initializer) Reset() error {
 			continue
 		}
 		name := file.Name()
-		if shared.IsInitFile(info) || name == metadataFileName {
+		if shared.IsInitFile(info) || name == MetadataFileName {
 			path := filepath.Join(init.opts.DataDir, name)
 			if err := os.Remove(path); err != nil {
 				return fmt.Errorf("failed to delete file (%v): %w", path, err)

--- a/initialization/metadata.go
+++ b/initialization/metadata.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spacemeshos/post/shared"
 )
 
-const metadataFileName = "postdata_metadata.json"
+const MetadataFileName = "postdata_metadata.json"
 
 func SaveMetadata(dir string, v *shared.PostMetadata) error {
 	err := os.MkdirAll(dir, shared.OwnerReadWriteExec)
@@ -22,7 +22,7 @@ func SaveMetadata(dir string, v *shared.PostMetadata) error {
 		return fmt.Errorf("serialization failure: %w", err)
 	}
 
-	err = os.WriteFile(filepath.Join(dir, metadataFileName), data, shared.OwnerReadWrite)
+	err = os.WriteFile(filepath.Join(dir, MetadataFileName), data, shared.OwnerReadWrite)
 	if err != nil {
 		return fmt.Errorf("write to disk failure: %w", err)
 	}
@@ -31,7 +31,7 @@ func SaveMetadata(dir string, v *shared.PostMetadata) error {
 }
 
 func LoadMetadata(dir string) (*shared.PostMetadata, error) {
-	filename := filepath.Join(dir, metadataFileName)
+	filename := filepath.Join(dir, MetadataFileName)
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
Closes #198.

Simple verification of the private key in `key.bin` against the NodeID in `postdata_metadata.json`. Will be done when `-verify` is set.