### PR TITLE
Fix incorrect seed length during verify

### DIFF
--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -290,7 +290,7 @@ func cmdVerifyPos(opts config.InitOpts, fraction float64, logger *zap.Logger) {
 	if n != ed25519.PrivateKeySize {
 		log.Fatalf("size of key (%d) not expected size %d\n", n, ed25519.PrivateKeySize)
 	}
-	pub := ed25519.NewKeyFromSeed(dst).Public().(ed25519.PublicKey)
+	pub := ed25519.NewKeyFromSeed(dst[:ed25519.SeedSize]).Public().(ed25519.PublicKey)
 
 	metafile := filepath.Join(opts.DataDir, initialization.MetadataFileName)
 	meta, err := initialization.LoadMetadata(opts.DataDir)


### PR DESCRIPTION
In #205 the whole private key is passed to `ed25519.NewKeyFromSeed` while it should only be the first 32 bytes (the seed - the rest is the public key).

This PR fixes this oversight.