### PR TITLE
Remove best provider and make ProviderID mandatory in InitOpts

### DIFF
--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -66,7 +66,8 @@ func parseFlags() {
 
 	flag.StringVar(&opts.DataDir, "datadir", opts.DataDir, "filesystem datadir path")
 	flag.Uint64Var(&opts.MaxFileSize, "maxFileSize", opts.MaxFileSize, "max file size")
-	flag.IntVar(&opts.ProviderID, "provider", opts.ProviderID, "compute provider id (required)")
+	var providerID uint64
+	flag.Uint64Var(&providerID, "provider", math.MaxUint64, "compute provider id (required)")
 	flag.Uint64Var(&cfg.LabelsPerUnit, "labelsPerUnit", cfg.LabelsPerUnit, "the number of labels per unit")
 	flag.BoolVar(&reset, "reset", false, "whether to reset the datadir before starting")
 	flag.StringVar(&idHex, "id", "", "miner's id (public key), in hex (will be auto-generated if not provided)")
@@ -83,11 +84,16 @@ func parseFlags() {
 	if to != math.MaxInt {
 		opts.ToFileIdx = &to
 	}
+	if providerID != math.MaxUint64 {
+		opts.ProviderID = new(uint32)
+		*opts.ProviderID = uint32(providerID)
+	}
+
 	opts.NumUnits = uint32(*numUnits) // workaround the missing type support for uint32
 }
 
 func processFlags() error {
-	if opts.ProviderID < 0 {
+	if opts.ProviderID == nil {
 		return errors.New("-provider flag is required")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ type InitOpts struct {
 	DataDir     string
 	NumUnits    uint32
 	MaxFileSize uint64
-	ProviderID  int
+	ProviderID  *uint32
 	Throttle    bool
 	Scrypt      ScryptParams
 	// ComputeBatchSize must be greater than 0
@@ -175,17 +175,12 @@ func DefaultLabelParams() ScryptParams {
 	}
 }
 
-// BestProviderID can be used for selecting the most performant provider
-// based on a short benchmarking session.
-const BestProviderID = -1
-
 // MainnetInitOpts returns the default InitOpts for mainnet.
 func MainnetInitOpts() InitOpts {
 	return InitOpts{
 		DataDir:          DefaultDataDir,
 		NumUnits:         4,
 		MaxFileSize:      defaultMaxFileSize,
-		ProviderID:       BestProviderID,
 		Throttle:         false,
 		Scrypt:           DefaultLabelParams(),
 		ComputeBatchSize: DefaultComputeBatchSize,
@@ -198,7 +193,6 @@ func DefaultInitOpts() InitOpts {
 		DataDir:          DefaultDataDir,
 		NumUnits:         2,
 		MaxFileSize:      defaultMaxFileSize,
-		ProviderID:       BestProviderID,
 		Throttle:         false,
 		Scrypt:           DefaultLabelParams(),
 		ComputeBatchSize: DefaultComputeBatchSize,
@@ -206,6 +200,10 @@ func DefaultInitOpts() InitOpts {
 }
 
 func Validate(cfg Config, opts InitOpts) error {
+	if opts.ProviderID == nil {
+		return errors.New("invalid `opts.ProviderID`; value not set")
+	}
+
 	if opts.NumUnits < cfg.MinNumUnits {
 		return fmt.Errorf("invalid `opts.NumUnits`; expected: >= %d, given: %d", cfg.MinNumUnits, opts.NumUnits)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -200,10 +200,6 @@ func DefaultInitOpts() InitOpts {
 }
 
 func Validate(cfg Config, opts InitOpts) error {
-	if opts.ProviderID == nil {
-		return errors.New("invalid `opts.ProviderID`; value not set")
-	}
-
 	if opts.NumUnits < cfg.MinNumUnits {
 		return fmt.Errorf("invalid `opts.NumUnits`; expected: >= %d, given: %d", cfg.MinNumUnits, opts.NumUnits)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,13 +36,27 @@ func TestTotalFiles(t *testing.T) {
 	r.Equal(0, opts.TotalFiles(128))
 }
 
-func TestOptsValidateScryptParams(t *testing.T) {
+func TestOptsValidateProviderID(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()
 	opts := config.DefaultInitOpts()
 
-	require.Nil(t, config.Validate(cfg, opts))
+	require.ErrorContains(t, config.Validate(cfg, opts), "invalid `opts.ProviderID`; value not set")
+
+	opts.ProviderID = new(uint32)
+	*opts.ProviderID = 1
+	require.NoError(t, config.Validate(cfg, opts))
+}
+
+func TestOptsValidateScryptParams(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	opts := config.DefaultInitOpts()
+	opts.ProviderID = new(uint32)
+	*opts.ProviderID = 1
+
+	require.NoError(t, config.Validate(cfg, opts))
 
 	opts.Scrypt.N = 0
-	require.Error(t, config.Validate(cfg, opts))
+	require.ErrorContains(t, config.Validate(cfg, opts), "scrypt parameter N cannot be 0")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,18 +36,6 @@ func TestTotalFiles(t *testing.T) {
 	r.Equal(0, opts.TotalFiles(128))
 }
 
-func TestOptsValidateProviderID(t *testing.T) {
-	t.Parallel()
-	cfg := config.DefaultConfig()
-	opts := config.DefaultInitOpts()
-
-	require.ErrorContains(t, config.Validate(cfg, opts), "invalid `opts.ProviderID`; value not set")
-
-	opts.ProviderID = new(uint32)
-	*opts.ProviderID = 1
-	require.NoError(t, config.Validate(cfg, opts))
-}
-
 func TestOptsValidateScryptParams(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -45,7 +45,7 @@ func OpenCLProviders() ([]Provider, error) {
 }
 
 // CPUProviderID returns the ID of the CPU provider or nil if the CPU provider is not available.
-func CPUProviderID() uint {
+func CPUProviderID() uint32 {
 	return postrs.CPUProviderID()
 }
 
@@ -237,8 +237,9 @@ func NewInitializer(opts ...OptionFunc) (*Initializer, error) {
 			init.nonceValue.Store(&nonceValue)
 		case m.Nonce != nil:
 			// there is a nonce in the metadata but no nonce value
+			cpuProviderID := CPUProviderID()
 			wo, err := oracle.New(
-				oracle.WithProviderID(CPUProviderID()),
+				oracle.WithProviderID(&cpuProviderID),
 				oracle.WithCommitment(init.commitment),
 				oracle.WithVRFDifficulty(make([]byte, 32)), // we are not looking for it, so set difficulty to 0
 				oracle.WithScryptParams(init.opts.Scrypt),
@@ -303,7 +304,7 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 	batchSize := init.opts.ComputeBatchSize
 
 	wo, err := oracle.New(
-		oracle.WithProviderID(uint(init.opts.ProviderID)),
+		oracle.WithProviderID(init.opts.ProviderID),
 		oracle.WithCommitment(init.commitment),
 		oracle.WithVRFDifficulty(difficulty),
 		oracle.WithScryptParams(init.opts.Scrypt),
@@ -316,8 +317,9 @@ func (init *Initializer) Initialize(ctx context.Context) error {
 
 	woReference := init.referenceOracle
 	if woReference == nil {
+		cpuProvider := CPUProviderID()
 		woReference, err = oracle.New(
-			oracle.WithProviderID(CPUProviderID()),
+			oracle.WithProviderID(&cpuProvider),
 			oracle.WithCommitment(init.commitment),
 			oracle.WithVRFDifficulty(difficulty),
 			oracle.WithScryptParams(init.opts.Scrypt),

--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -814,6 +814,7 @@ func TestWrongLabelsDetected(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	woReference, err := oracle.New(
+		oracle.WithProviderID(opts.ProviderID),
 		oracle.WithCommitment(make([]byte, 32)), // different commitment to trigger error
 		oracle.WithScryptParams(opts.Scrypt),
 		oracle.WithVRFDifficulty(make([]byte, 32)),

--- a/initialization/pos_verification_test.go
+++ b/initialization/pos_verification_test.go
@@ -9,21 +9,13 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/spacemeshos/post/config"
 	"github.com/spacemeshos/post/internal/postrs"
 )
 
 func TestVerifyPos(t *testing.T) {
-	t.Parallel()
-	cfg := config.DefaultConfig()
-	cfg.LabelsPerUnit = 128
-
-	opts := config.DefaultInitOpts()
-	opts.DataDir = t.TempDir()
+	cfg, opts := getTestConfig(t)
 	opts.NumUnits = 5
 	opts.MaxFileSize = 2 * cfg.UnitSize()
-	opts.ProviderID = int(CPUProviderID())
-	opts.Scrypt.N = 2
 
 	init, err := NewInitializer(
 		WithNodeId(nodeId),

--- a/initialization/vrf_search.go
+++ b/initialization/vrf_search.go
@@ -70,7 +70,9 @@ func SearchForNonce(ctx context.Context, cfg Config, initOpts InitOpts, opts ...
 		return 0, nil, fmt.Errorf("couldn't open the data directory: %w", err)
 	}
 
+	cpuProviderID := CPUProviderID()
 	woReference, err := oracle.New(
+		oracle.WithProviderID(&cpuProviderID),
 		oracle.WithCommitment(metadata.CommitmentAtxId),
 		oracle.WithVRFDifficulty(difficulty),
 		oracle.WithScryptParams(initOpts.Scrypt),

--- a/initialization/vrf_search.go
+++ b/initialization/vrf_search.go
@@ -71,7 +71,6 @@ func SearchForNonce(ctx context.Context, cfg Config, initOpts InitOpts, opts ...
 	}
 
 	woReference, err := oracle.New(
-		oracle.WithProviderID(CPUProviderID()),
 		oracle.WithCommitment(metadata.CommitmentAtxId),
 		oracle.WithVRFDifficulty(difficulty),
 		oracle.WithScryptParams(initOpts.Scrypt),

--- a/initialization/vrf_search_test.go
+++ b/initialization/vrf_search_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestCheckLabel(t *testing.T) {
 	woReference, err := oracle.New(
-		oracle.WithProviderID(CPUProviderID()),
 		oracle.WithCommitment(make([]byte, 32)),
 		oracle.WithVRFDifficulty(make([]byte, 32)),
 		oracle.WithScryptParams(config.ScryptParams{
@@ -69,15 +68,9 @@ func TestCheckLabel(t *testing.T) {
 
 func TestSearchForNonce(t *testing.T) {
 	// Initialize some data first
-	cfg := config.DefaultConfig()
-	cfg.LabelsPerUnit = 128
-
-	opts := config.DefaultInitOpts()
-	opts.DataDir = t.TempDir()
+	cfg, opts := getTestConfig(t)
 	opts.NumUnits = 20
 	opts.MaxFileSize = cfg.UnitSize() * 2
-	opts.ProviderID = int(CPUProviderID())
-	opts.Scrypt.N = 2
 
 	logger := zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))
 
@@ -133,15 +126,9 @@ func TestSearchForNonce(t *testing.T) {
 }
 
 func TestSearchForNonceNotFound(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.LabelsPerUnit = 128
-
-	opts := config.DefaultInitOpts()
-	opts.DataDir = t.TempDir()
+	cfg, opts := getTestConfig(t)
 	opts.NumUnits = 10
 	opts.MaxFileSize = cfg.UnitSize() * 2
-	opts.ProviderID = int(CPUProviderID())
-	opts.Scrypt.N = 2
 
 	logger := zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))
 

--- a/initialization/vrf_search_test.go
+++ b/initialization/vrf_search_test.go
@@ -10,11 +10,14 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/post/config"
+	"github.com/spacemeshos/post/internal/postrs"
 	"github.com/spacemeshos/post/oracle"
 )
 
 func TestCheckLabel(t *testing.T) {
+	cpuProviderID := postrs.CPUProviderID()
 	woReference, err := oracle.New(
+		oracle.WithProviderID(&cpuProviderID),
 		oracle.WithCommitment(make([]byte, 32)),
 		oracle.WithVRFDifficulty(make([]byte, 32)),
 		oracle.WithScryptParams(config.ScryptParams{

--- a/internal/postrs/api.go
+++ b/internal/postrs/api.go
@@ -21,7 +21,7 @@ func OpenCLProviders() ([]Provider, error) {
 	return cGetProviders()
 }
 
-func CPUProviderID() uint {
+func CPUProviderID() uint32 {
 	return cCPUProviderID()
 }
 
@@ -37,7 +37,7 @@ type Scrypter interface {
 }
 
 type option struct {
-	providerID *uint
+	providerID *uint32
 
 	commitment    []byte
 	n             uint
@@ -66,9 +66,9 @@ func (o *option) validate() error {
 type OptionFunc func(*option) error
 
 // WithProviderID sets the ID of the openCL provider to use.
-func WithProviderID(id uint) OptionFunc {
+func WithProviderID(id uint32) OptionFunc {
 	return func(opts *option) error {
-		opts.providerID = new(uint)
+		opts.providerID = new(uint32)
 		*opts.providerID = id
 		return nil
 	}

--- a/internal/postrs/api_test.go
+++ b/internal/postrs/api_test.go
@@ -131,7 +131,7 @@ func TestScrypt_Close(t *testing.T) {
 }
 
 func TestScryptPositions_InvalidProviderId(t *testing.T) {
-	invalidProviderId := uint(1 << 10)
+	invalidProviderId := uint32(1 << 10)
 	_, err := NewScrypt(
 		WithProviderID(invalidProviderId),
 		WithCommitment(commitment),

--- a/internal/postrs/device_mutex.go
+++ b/internal/postrs/device_mutex.go
@@ -9,15 +9,15 @@ import "sync"
 // mutex for a given device ID in a thread-safe manner.
 type deviceMutex struct {
 	mtx    sync.Mutex
-	device map[uint]*sync.Mutex
+	device map[uint32]*sync.Mutex
 }
 
-func (g *deviceMutex) Device(deviceId uint) *sync.Mutex {
+func (g *deviceMutex) Device(deviceId uint32) *sync.Mutex {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
 
 	if g.device == nil {
-		g.device = make(map[uint]*sync.Mutex)
+		g.device = make(map[uint32]*sync.Mutex)
 	}
 
 	if _, ok := g.device[deviceId]; !ok {

--- a/internal/postrs/initializer.go
+++ b/internal/postrs/initializer.go
@@ -26,7 +26,7 @@ const (
 // libpostrs returns a list of these structs when calling cGetProviders().
 // Each Provider is an OpenCL platform + Device combination.
 type Provider struct {
-	ID         uint
+	ID         uint32
 	Model      string
 	DeviceType DeviceClass
 }
@@ -130,7 +130,7 @@ func cScryptPositions(init *C.Initializer, opt *option, start, end uint64) ([]by
 }
 
 // cCPUProviderID returns the ID for the (non OpenCL) CPU provider.
-func cCPUProviderID() uint {
+func cCPUProviderID() uint32 {
 	return C.CPU_PROVIDER_ID
 }
 
@@ -150,7 +150,7 @@ func cGetProviders() ([]Provider, error) {
 	}
 
 	for i := uint(0); i < uint(cNumProviders); i++ {
-		providers[i].ID = (uint)(cProviders[i].id)
+		providers[i].ID = (uint32)(cProviders[i].id)
 		providers[i].Model = C.GoString(&cProviders[i].name[0])
 		providers[i].DeviceType = DeviceClass(cProviders[i].class_)
 	}

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -31,10 +31,6 @@ type option struct {
 }
 
 func (o *option) validate() error {
-	if o.providerID == nil {
-		return errors.New("`providerID` is required")
-	}
-
 	if o.commitment == nil {
 		return errors.New("`commitment` is required")
 	}
@@ -168,8 +164,6 @@ func New(opts ...OptionFunc) (*WorkOracle, error) {
 		retryDelay: time.Second,
 		logger:     zap.NewNop(),
 	}
-	options.providerID = new(uint32)
-	*options.providerID = postrs.CPUProviderID()
 
 	for _, opt := range opts {
 		if err := opt(options); err != nil {
@@ -184,6 +178,10 @@ func New(opts ...OptionFunc) (*WorkOracle, error) {
 	scrypt := options.scrypter
 	if scrypt == nil {
 		scrypt = &LazyScrypter{init: func() (postrs.Scrypter, error) {
+			if options.providerID == nil {
+				return nil, errors.New("no provider specified")
+			}
+
 			return postrs.NewScrypt(
 				postrs.WithProviderID(*options.providerID),
 				postrs.WithCommitment(options.commitment),

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -16,7 +16,7 @@ import (
 var ErrWorkOracleClosed = errors.New("work oracle has been closed")
 
 type option struct {
-	providerID *uint
+	providerID *uint32
 
 	commitment    []byte
 	n             uint
@@ -53,11 +53,10 @@ func (o *option) validate() error {
 // OptionFunc is a function that sets an option for a WorkOracle instance.
 type OptionFunc func(*option) error
 
-// WithProviderID sets the ID of the openCL provider to use.
-func WithProviderID(id uint) OptionFunc {
+// WithProviderID sets the ID of the OpenCL provider to use.
+func WithProviderID(id *uint32) OptionFunc {
 	return func(opts *option) error {
-		opts.providerID = new(uint)
-		*opts.providerID = id
+		opts.providerID = id
 		return nil
 	}
 }
@@ -169,7 +168,7 @@ func New(opts ...OptionFunc) (*WorkOracle, error) {
 		retryDelay: time.Second,
 		logger:     zap.NewNop(),
 	}
-	options.providerID = new(uint)
+	options.providerID = new(uint32)
 	*options.providerID = postrs.CPUProviderID()
 
 	for _, opt := range opts {

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -16,7 +16,13 @@ func TestOracleRetryPositions(t *testing.T) {
 	commitment := make([]byte, 32)
 	vrfDifficulty := make([]byte, 32)
 	mockScrypter := mocks.NewMockScrypter(gomock.NewController(t))
-	o, err := New(WithCommitment(commitment), WithVRFDifficulty(vrfDifficulty), WithMaxRetries(2), WithRetryDelay(0), withScrypter(mockScrypter))
+	o, err := New(
+		WithCommitment(commitment),
+		WithVRFDifficulty(vrfDifficulty),
+		WithMaxRetries(2),
+		WithRetryDelay(0),
+		withScrypter(mockScrypter),
+	)
 
 	t.Run("retries max time and quits", func(t *testing.T) {
 		mockScrypter.EXPECT().Positions(uint64(0), uint64(10)).Return(postrs.ScryptPositionsResult{}, postrs.ErrInitializationFailed).Times(3)
@@ -37,16 +43,38 @@ func TestOracleRetryPositions(t *testing.T) {
 	})
 }
 
+func TestOracleErrorsOnMissingProviderID(t *testing.T) {
+	t.Parallel()
+	commitment := make([]byte, 32)
+	vrfDifficulty := make([]byte, 32)
+	o, err := New(
+		WithCommitment(commitment),
+		WithVRFDifficulty(vrfDifficulty),
+		WithMaxRetries(2),
+		WithRetryDelay(0),
+	)
+	require.NoError(t, err)
+
+	_, err = o.Position(10)
+	require.ErrorContains(t, err, "no provider specified")
+}
+
 func TestOracleFailsOnInvalidIndices(t *testing.T) {
 	t.Parallel()
 	commitment := make([]byte, 32)
 	vrfDifficulty := make([]byte, 32)
 	mockScrypter := mocks.NewMockScrypter(gomock.NewController(t))
-	o, err := New(WithCommitment(commitment), WithVRFDifficulty(vrfDifficulty), WithMaxRetries(2), WithRetryDelay(0), withScrypter(mockScrypter))
+	o, err := New(
+		WithCommitment(commitment),
+		WithVRFDifficulty(vrfDifficulty),
+		WithMaxRetries(2),
+		WithRetryDelay(0),
+		withScrypter(mockScrypter),
+	)
 	require.NoError(t, err)
 
 	_, err = o.Positions(10, 0)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid `start` and `end`")
 }
 
 func TestOracleCantInitializeAfterClose(t *testing.T) {
@@ -54,7 +82,13 @@ func TestOracleCantInitializeAfterClose(t *testing.T) {
 	commitment := make([]byte, 32)
 	vrfDifficulty := make([]byte, 32)
 	mockScrypter := mocks.NewMockScrypter(gomock.NewController(t))
-	o, err := New(WithCommitment(commitment), WithVRFDifficulty(vrfDifficulty), WithMaxRetries(2), WithRetryDelay(0), withScrypter(mockScrypter))
+	o, err := New(
+		WithCommitment(commitment),
+		WithVRFDifficulty(vrfDifficulty),
+		WithMaxRetries(2),
+		WithRetryDelay(0),
+		withScrypter(mockScrypter),
+	)
 	require.NoError(t, err)
 
 	mockScrypter.EXPECT().Close().Return(nil).Times(1)

--- a/proving/proving_test.go
+++ b/proving/proving_test.go
@@ -26,7 +26,8 @@ func getTestConfig(tb testing.TB) (config.Config, config.InitOpts) {
 	opts.Scrypt.N = 16 // speed up initialization
 	opts.DataDir = tb.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
-	opts.ProviderID = int(postrs.CPUProviderID())
+	opts.ProviderID = new(uint32)
+	*opts.ProviderID = postrs.CPUProviderID()
 	opts.ComputeBatchSize = 1 << 14
 	return cfg, opts
 }
@@ -187,7 +188,8 @@ func Test_Generate_TestNetSettings(t *testing.T) {
 
 	opts := config.DefaultInitOpts()
 	opts.Scrypt.N = 16
-	opts.ProviderID = int(postrs.CPUProviderID())
+	opts.ProviderID = new(uint32)
+	*opts.ProviderID = postrs.CPUProviderID()
 	opts.NumUnits = 2
 	opts.DataDir = t.TempDir()
 

--- a/verifying/verifying.go
+++ b/verifying/verifying.go
@@ -37,7 +37,9 @@ func VerifyVRFNonce(nonce *uint64, m *shared.VRFNonceMetadata, opts ...OptionFun
 	numLabels := uint64(m.NumUnits) * uint64(m.LabelsPerUnit)
 	difficulty := shared.PowDifficulty(numLabels)
 
+	cpuProviderID := postrs.CPUProviderID()
 	wo, err := oracle.New(
+		oracle.WithProviderID(&cpuProviderID),
 		oracle.WithCommitment(oracle.CommitmentBytes(m.NodeId, m.CommitmentAtxId)),
 		oracle.WithScryptParams(options.labelScrypt),
 		oracle.WithVRFDifficulty(difficulty),

--- a/verifying/verifying_test.go
+++ b/verifying/verifying_test.go
@@ -25,13 +25,11 @@ func getTestConfig(tb testing.TB) (config.Config, config.InitOpts) {
 	cfg.K2 = 3
 	cfg.K3 = 3
 
-	id := postrs.CPUProviderID()
-	require.NotZero(tb, id)
-
 	opts := config.DefaultInitOpts()
 	opts.DataDir = tb.TempDir()
 	opts.NumUnits = cfg.MinNumUnits
-	opts.ProviderID = int(id)
+	opts.ProviderID = new(uint32)
+	*opts.ProviderID = postrs.CPUProviderID()
 	opts.ComputeBatchSize = 1 << 14
 	return cfg, opts
 }


### PR DESCRIPTION
Part of https://github.com/spacemeshos/post/issues/212

- Removes `BestProviderID`
- Change ProviderID from `uint` to `*uint32`
- Removes default ProviderID in `DefaultInitOpts`
- Makes selecting a provider ID in `postcli` mandatory (before defaulted to CPU)