### PR TITLE
Change logging level of message to avoid confusion.

### DIFF
--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -410,6 +410,7 @@ func removeRedundantFiles(cfg config.Config, opts config.InitOpts, logger *zap.L
 		name := file.Name()
 		fileIndex, err := shared.ParseFileIndex(name)
 		if err != nil && name != MetadataFileName {
+			// TODO(mafa): revert back to warning, see https://github.com/spacemeshos/go-spacemesh/issues/4789
 			logger.Debug("found unrecognized file", zap.String("fileName", name))
 			continue
 		}

--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -410,7 +410,7 @@ func removeRedundantFiles(cfg config.Config, opts config.InitOpts, logger *zap.L
 		name := file.Name()
 		fileIndex, err := shared.ParseFileIndex(name)
 		if err != nil && name != MetadataFileName {
-			logger.Warn("found unrecognized file", zap.String("fileName", name))
+			logger.Debug("found unrecognized file", zap.String("fileName", name))
 			continue
 		}
 		if fileIndex > maxFileIndex {


### PR DESCRIPTION
A simple temporary workaround for the issue https://github.com/spacemeshos/go-spacemesh/issues/4789

This changes the level of logging messages that report unrecognised files from WARN to DEBUG.

PoST ignores files it doesn't know. At the moment the node creates additional files in the data directory. PoST reporting them as warning to users might mislead them into believing these files don't belong there or shall be deleted. Only showing these messages when debug logging is active should prevent this.