### PR TITLE
Remove obsolete TODO for logging unknown files.

### DIFF
--- a/initialization/initialization.go
+++ b/initialization/initialization.go
@@ -410,7 +410,6 @@ func removeRedundantFiles(cfg config.Config, opts config.InitOpts, logger *zap.L
 		name := file.Name()
 		fileIndex, err := shared.ParseFileIndex(name)
 		if err != nil && name != MetadataFileName {
-			// TODO(mafa): revert back to warning, see https://github.com/spacemeshos/go-spacemesh/issues/4789
 			logger.Debug("found unrecognized file", zap.String("fileName", name))
 			continue
 		}


### PR DESCRIPTION
Closes https://github.com/spacemeshos/go-spacemesh/issues/4789

PoST should not complain about any files it finds in the data folder it doesn't know about. As explained in the issue there could be a lot of files that are just created by the OS that the operator of the node might not be aware about or can even remove from the directory.

We should keep the log as debug and close the issue.