### PR TITLE
Check version of libpost

### DIFF
--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -50,7 +50,8 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.6.4
+# Also update 'SUPPORTED_VERSION' in internal/postrs/version_check.go
+POSTRS_SETUP_REV = 0.6.5-rc1
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -51,7 +51,7 @@ else
 endif
 
 # Also update 'SUPPORTED_VERSION' in internal/postrs/version_check.go
-POSTRS_SETUP_REV = 0.6.5-rc1
+POSTRS_SETUP_REV = 0.6.5
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/internal/postrs/version_check.go
+++ b/internal/postrs/version_check.go
@@ -1,0 +1,36 @@
+package postrs
+
+// #cgo LDFLAGS: -lpost
+// #include "post.h"
+import "C"
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	// regexp matching supported versions of post-rs library
+	SUPPORTED_VERSION = `0\.6\.([5-9]|[1-9][0-9]+)` // 0.6.5+
+	// Set this env variable to "true" or "1" to disable version check.
+	DISABLE_CKECK_ENV = "LIBPOST_DISABLE_VERSION_CHECK"
+)
+
+func init() {
+	checkDisabledEnv := strings.ToLower(os.Getenv(DISABLE_CKECK_ENV))
+	if checkDisabledEnv == "true" || checkDisabledEnv == "1" {
+		return
+	}
+	version := Version()
+	if !regexp.MustCompile(SUPPORTED_VERSION).Match([]byte(version)) {
+		msgFmt := `Unsupported version of post library (post.dll/libpost.dll/libpost.dylib):
+	got: "%s"
+	supported: "%s"`
+		panic(fmt.Sprintf(msgFmt, version, SUPPORTED_VERSION))
+	}
+}
+
+func Version() string {
+	return C.GoString(C.version())
+}

--- a/internal/postrs/version_check.go
+++ b/internal/postrs/version_check.go
@@ -3,6 +3,7 @@ package postrs
 // #cgo LDFLAGS: -lpost
 // #include "post.h"
 import "C"
+
 import (
 	"fmt"
 	"os"


### PR DESCRIPTION
Check version of post-rs library when `postrs` package is loaded (on `init()`). Panic if the version doesn't match the supported version regexp. 
The version check can be disabled with an env variable `LIBPOST_DISABLE_VERSION_CHECK=true/1`.

Depends on https://github.com/spacemeshos/post-rs/pull/176