### PR TITLE
Add option to keep redundant files

### DIFF
--- a/initialization/initialization_test.go
+++ b/initialization/initialization_test.go
@@ -1113,7 +1113,7 @@ func TestRemoveRedundantFiles(t *testing.T) {
 		require.NoError(t, f.Close())
 	}
 
-	removeRedundantFiles(cfg, opts, zap.NewNop())
+	checkRedundantFiles(cfg, opts, false, zap.NewNop())
 
 	files, err := os.ReadDir(opts.DataDir)
 	require.NoError(t, err)


### PR DESCRIPTION
A long-standing pain point for go-spacemesh users is that it simply deletes postdata files that are deemed "redundant". For a go-spacemesh managed through smapp, the behaviour may be reasonable and comprehensible. For CLI users, however, this often means that a simple config mistake of setting the wrong num-units in the config file leads to weeks of postdata file initialisation being quickly wiped out.

With this change, the current default behaviour is preserved: redundant files are deleted. If the new option is enabled, an info entry is logged for redundant files, but they are not deleted.

This change prepares the stage for a dependent change in go-spacemesh. 