### PR TITLE
Fix nil exception in numUnits check

### DIFF
--- a/cmd/postcli/README.md
+++ b/cmd/postcli/README.md
@@ -161,8 +161,9 @@ ls -la ./data/*.bin | wc -l
 1600
 ```
 
-**Merging postmeta_data.json**: Every subset will create its own `postmeta_data.json`. These files MUST be merged manually.
-During initialization a VRF nonce is searched that represents the index of the **the label with the smallest value**.
+**Merging postdata_metadata.json**: Every subset will create its own `postdata_metadata.json`. These files MUST be
+merged manually. During initialization a VRF nonce is searched that represents the index of the
+**the label with the smallest value**.
 
 When `postcli` initializes in chunks, each subset can find a valid VRF nonce, which represents the local minimum in the
 initialized subset. It is **necessary** to manually select the best one (the global minimum) when merging the subsets.

--- a/cmd/postcli/main.go
+++ b/cmd/postcli/main.go
@@ -151,7 +151,7 @@ func processFlags() {
 		log.Fatalln("-numUnits must be specified to perform initialization.")
 	}
 
-	if flagSet["numUnits"] && numUnits != uint64(meta.NumUnits) {
+	if flagSet["numUnits"] && meta != nil && numUnits != uint64(meta.NumUnits) {
 		log.Println("WARNING: it appears that", opts.DataDir, "was previously initialized with a different `numUnits` value.")
 		log.Println("\tCurrent value:", meta.NumUnits)
 		log.Println("\tValue passed to postcli:", numUnits)


### PR DESCRIPTION
When initializing a new PoST data dir a nil pointer exception would occur when providing a `numUnits` value.

This fixes this exception.