### PR TITLE
Fix scrypt close

### DIFF
--- a/internal/postrs/api.go
+++ b/internal/postrs/api.go
@@ -151,6 +151,9 @@ func NewScrypt(opts ...OptionFunc) (*Scrypt, error) {
 
 // Close closes the Scrypt instance.
 func (s *Scrypt) Close() error {
+	if s == nil {
+		return nil
+	}
 	if s.init == nil {
 		return ErrScryptClosed
 	}

--- a/internal/postrs/api_test.go
+++ b/internal/postrs/api_test.go
@@ -49,34 +49,36 @@ func TestScryptPositions(t *testing.T) {
 	var prevOutput []byte
 	var nonce *uint64
 	for _, p := range providers {
-		scrypt, err := NewScrypt(
-			WithProviderID(p.ID),
-			WithCommitment(commitment),
-			WithVRFDifficulty(vrfDifficulty),
-			WithScryptN(32),
-			WithLogger(zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))),
-		)
-		require.NoError(t, err)
-		require.NotNil(t, scrypt)
-		defer scrypt.Close()
+		t.Run(p.Model, func(t *testing.T) {
+			scrypt, err := NewScrypt(
+				WithProviderID(p.ID),
+				WithCommitment(commitment),
+				WithVRFDifficulty(vrfDifficulty),
+				WithScryptN(32),
+				WithLogger(zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, scrypt)
+			defer scrypt.Close()
 
-		res, err := scrypt.Positions(start, end)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-		require.NotNil(t, res.Output)
+			res, err := scrypt.Positions(start, end)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.NotNil(t, res.Output)
 
-		// assert that output content is equal between different providers.
-		if prevOutput == nil {
-			prevOutput = res.Output
-		} else {
-			require.Equal(t, prevOutput, res.Output, fmt.Sprintf("not equal: provider: %+v", p))
-		}
+			// assert that output content is equal between different providers.
+			if prevOutput == nil {
+				prevOutput = res.Output
+			} else {
+				require.Equal(t, prevOutput, res.Output, fmt.Sprintf("not equal: provider: %+v", p))
+			}
 
-		if nonce == nil {
-			nonce = res.IdxSolution
-		} else {
-			require.Equal(t, *nonce, *res.IdxSolution)
-		}
+			if nonce == nil {
+				nonce = res.IdxSolution
+			} else {
+				require.Equal(t, *nonce, *res.IdxSolution)
+			}
+		})
 	}
 
 	require.NotNil(t, prevOutput)

--- a/internal/postrs/api_test.go
+++ b/internal/postrs/api_test.go
@@ -216,3 +216,8 @@ func Test_ScryptPositions_NoPow(t *testing.T) {
 		})
 	}
 }
+
+func TestCloseNilScrypt(t *testing.T) {
+	var scrypt *Scrypt
+	scrypt.Close()
+}


### PR DESCRIPTION
Fix segfaults when closing a `postrs.Scrypt` instance that first failed creation. Additionally, fix a deadlock in UT on platforms with more than 1 GPU.