### PR TITLE
Fix passing invalid log level to postrs logger

### DIFF
--- a/internal/postrs/log.go
+++ b/internal/postrs/log.go
@@ -42,13 +42,19 @@ var (
 )
 
 func setLogCallback(logger *zap.Logger) {
-	oncer.Do(func() {
-		C.set_logging_callback(levelMap[logger.Level()], C.callback(C.logCallback))
-	})
+	level, ok := levelMap[logger.Level()]
+	if !ok {
+		logger.Error("failed to map zap log level to C log level", zap.Stringer("level", logger.Level()))
+		return
+	}
 
 	logMux.Lock()
-	defer logMux.Unlock()
 	log = logger
+	logMux.Unlock()
+
+	oncer.Do(func() {
+		C.set_logging_callback(level, C.callback(C.logCallback))
+	})
 }
 
 //export logCallback


### PR DESCRIPTION
The zap noop logger has `zapcore.InvalidLevel` log level, which is not represented in the go -> C log levels mapping. The current code, for the noop logger, passes a default Level value of 0. This is not valid and causes undefined behavior on the Rust side, which started to cause a crash since Rust 1.76.

The proper behavior is to not set the logger in such case.