### PR TITLE
Update use of macos runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          - macos-latest
+          - macos-13
           - [self-hosted, macos, arm64]
           - windows-latest
     steps:
@@ -109,7 +109,7 @@ jobs:
         os:
         - ubuntu-latest
         - [self-hosted, linux, arm64]
-        - macos-latest
+        - macos-13
         - [self-hosted, macos, arm64]
         - windows-latest
     steps:


### PR DESCRIPTION
`macos-latest` is now a arm machine. Update to use an intel builder instead