### PR TITLE
Remove duplicated LDFLAGS definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,16 +138,17 @@ jobs:
           cp ./cmd/postcli/README.md ./build/
       - name: Set name of release archive
         shell: bash
+        id: release-name
         run: |
           if [[ ${{ runner.arch }} == "ARM64" ]]; then
-            echo "OUTNAME=${{ runner.os }}_${{ runner.arch }}" >> $GITHUB_ENV
+            echo "name=${{ runner.os }}_${{ runner.arch }}" >> "$GITHUB_OUTPUT"
           else
-            echo "OUTNAME=${{ runner.os }}" >> $GITHUB_ENV
+            echo "name=${{ runner.os }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Archive postcli artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: postcli-${{ env.OUTNAME }}.zip
+          name: postcli-${{ steps.release-name.outputs.name }}.zip
           path: ./build/*
           if-no-files-found: error
 

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -37,7 +37,7 @@ else
 		else
 				platform := macos
 		endif
-		CGO_LDFLAGS := $(CGO_LDFLAGS) -Wl,-rpath,@loader_path
+		export GOFLAGS := '-ldflags=-extldflags=-Wl,-ld_classic'
 	else
 		ifeq ($(GOARCH),arm64)
 				platform := linux-arm64

--- a/internal/postrs/initializer.go
+++ b/internal/postrs/initializer.go
@@ -1,6 +1,5 @@
 package postrs
 
-// #cgo LDFLAGS: -lpost
 // #include <stdlib.h>
 // #include "post.h"
 import "C"

--- a/internal/postrs/log.go
+++ b/internal/postrs/log.go
@@ -1,6 +1,5 @@
 package postrs
 
-// #cgo LDFLAGS: -lpost
 // #include <stdlib.h>
 // #include "post.h"
 //

--- a/internal/postrs/pos_verifier.go
+++ b/internal/postrs/pos_verifier.go
@@ -1,6 +1,5 @@
 package postrs
 
-// #cgo LDFLAGS: -lpost
 // #include <stdlib.h>
 // #include "post.h"
 import "C"

--- a/internal/postrs/proof.go
+++ b/internal/postrs/proof.go
@@ -1,6 +1,5 @@
 package postrs
 
-// #cgo LDFLAGS: -lpost
 // #include <stdlib.h>
 // #include "post.h"
 import "C"

--- a/internal/postrs/version_check.go
+++ b/internal/postrs/version_check.go
@@ -1,6 +1,5 @@
 package postrs
 
-// #cgo LDFLAGS: -lpost
 // #include "post.h"
 import "C"
 


### PR DESCRIPTION
This should get rid of the warnings during macOS builds and tests.